### PR TITLE
Reclaim password focus when the field loses it

### DIFF
--- a/designs/DesignBase.qml
+++ b/designs/DesignBase.qml
@@ -146,4 +146,22 @@ Item {
 
   onInputEnabledChanged: if (inputEnabled) Qt.callLater(forcePasswordFocus)
   Component.onCompleted: if (inputEnabled) Qt.callLater(forcePasswordFocus)
+
+  // A suspend/resume cycle leaves the password field without item focus, and
+  // nothing here used to claim it back: inputEnabled stays true for the whole
+  // lock, so onInputEnabledChanged never fires, and Component.onCompleted ran
+  // long before. The lock screen then ignores the keyboard until the user
+  // clicks, or moves the pointer onto another output whose surface kept its
+  // focus.
+  //
+  // The surface keeps compositor keyboard focus across the cycle — only the
+  // item focus is lost — so the field itself is what has to be watched.
+  Connections {
+    target: base.inputItem
+    ignoreUnknownSignals: true
+    function onActiveFocusChanged() {
+      if (base.inputEnabled && base.inputItem && !base.inputItem.activeFocus)
+        Qt.callLater(base.forcePasswordFocus)
+    }
+  }
 }


### PR DESCRIPTION
After a suspend/resume cycle the lock screen ignores the keyboard. The password
field has lost its item focus and nothing claims it back, so typing goes
nowhere until the user clicks, or moves the pointer onto another output whose
surface still holds its focus.

None of the existing triggers cover this. `inputEnabled` stays true for the
whole lock, so `onInputEnabledChanged` never fires, and `Component.onCompleted`
ran long before the machine went to sleep. `onPositionChanged` only raises
`wakeRequested()`, which is why nudging the pointer on the same output does not
help either.

Measured on resume by logging `activeFocus` and password length: the field
loses focus 0.8 s after resume and nothing reclaims it. The surface keeps
compositor keyboard focus throughout — only the item focus is lost — so
watching the field itself is what catches it. With two outputs, the focus log
fires once while the length log fires twice, confirming that only the focused
surface is affected.

Fixing it in `DesignBase` covers every design at once.

Tested across several suspend/resume cycles on Hyprland with two outputs,
driver nvidia-580xx.

---

**Unrelated issue, for your information:** after resume the lock surface
swallows the first input event — a key or a pointer motion — and the next one
goes through. An unlocked session is not affected, and a pointer motion (which
never calls `forcePasswordFocus`) is enough to clear it, so this is below QML
rather than a focus problem. It was invisible before this patch because the
click users had to perform absorbed the swallowed event. Worth knowing if
anyone reports "the first keystroke is lost after resume".
