### PR TITLE
Make the unlock screen's blank delay configurable

### DIFF
--- a/Service.qml
+++ b/Service.qml
@@ -87,6 +87,24 @@ Item {
   readonly property int unlockDuration: unlockDurationOverride >= 0 ? unlockDurationOverride : configuredUnlockDuration
   readonly property bool unlockAnimated: unlockAnimation !== "none" && unlockDuration > 0
 
+  // How long the unlock screen stays lit before the display is blanked. The
+  // session is locked before every suspend, so on a machine that sleeps this
+  // delay is what the user sees on resume: too short and the screen goes dark
+  // before there is time to type. Saved on the plugin entry as `blankMs`.
+  readonly property int defaultBlankDelay: 5000
+  property int blankDelayOverride: -1
+  readonly property int configuredBlankDelay: {
+    var cfg = shell ? shell.shellConfig : null
+    var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
+    for (var i = 0; i < list.length; i++) {
+      var entry = list[i]
+      if (entry && String(entry.id || "") === pluginId && entry.blankMs !== undefined)
+        return Math.max(1000, Math.min(3600000, Number(entry.blankMs) || defaultBlankDelay))
+    }
+    return defaultBlankDelay
+  }
+  readonly property int blankDelay: blankDelayOverride >= 0 ? blankDelayOverride : configuredBlankDelay
+
   // Avatar picture for the designs that show the user. The chosen path lives on
   // the plugin entry in shell.json; "none" there means the user cleared it and
   // wants the initial back, an empty setting falls back to the usual dotfiles.
@@ -1908,7 +1926,7 @@ echo "$out"
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    interval: root.blankDelay
     repeat: false
     property double armedAt: 0
     onTriggered: {
@@ -2039,6 +2057,7 @@ echo "$out"
         unlock: root.unlockAnimation,
         unlockMs: root.unlockDuration,
         unlockAnimated: root.unlockAnimated,
+        blankMs: root.blankDelay,
         unlocking: root.unlocking,
         clipDesign: root.designHasClip,
         clipUnlocking: root.clipUnlocking,


### PR DESCRIPTION
### The problem

The unlock screen blanks the display 5 s after the lock is requested
(`idleBlankTimer`). That is a good default for a lock taken at the desk.

It is a poor one for a lock taken on the way to suspend. Omarchy locks the
session before every suspend (`omarchy-sleep-lock.service`), so on a machine
that sleeps, that countdown is what the user meets **on resume**: the screen
comes back, and five seconds later it goes dark again — before there is time to
reach the keyboard. You wake it, and it blanks again while you look for the
password field.

The resume guard already in the timer does not cover this: it prevents a
countdown *frozen by the suspend* from firing immediately, but the fresh one
armed after resume still runs its full 5 s.

### The change

`blankMs` on the plugin's shell.json entry, following `unlockMs` exactly — the
same lookup over `cfg.plugins`, the same clamp-and-default shape, the same
override property — and it joins the `lock status` output so the effective
value can be read back.

```json
{ "id": "io.github.sirjul1337.lock-explorer", "design": "rain", "blankMs": 600000 }
```

- Bounds: 1 s to 1 h.
- **Default unchanged at 5000**, so nothing moves for anyone who does not set it.
- The resume guard compares elapsed wall-clock time against `interval + 2000`,
  which now scales with the configured delay instead of being pinned to 7 s.

20 lines, one file, no new dependency.

### Tested

On a two-monitor Hyprland desktop that suspends after 2 h of inactivity:

| | |
|---|---|
| no `blankMs` set | `lock status` reports `blankMs: 5000`, blanking unchanged |
| `blankMs: 600000` | `lock status` reports `600000`, the unlock screen stays lit on resume |
| out of bounds (`50`, `99999999`) | clamped to 1000 / 3600000 |

Read back with:

```sh
omarchy-shell lock status | jq .blankMs
```
