### PR TITLE
Keep-display-on option: a "Never" for the blank delay, with a picker UI

### DIFF
--- a/Explorer.qml
+++ b/Explorer.qml
@@ -733,7 +733,7 @@ Item {
 
   function commitCustomDelay() {
     var minutes = Math.round(Number(root.customDelayText))
-    if (!isFinite(minutes) || minutes < 1 || minutes > 60) return
+    if (!isFinite(minutes) || minutes < 1 || minutes > 1440) return
     if (!root.service) return
     root.service.setKeepDisplayOn(false)
     root.service.setBlankDelay(minutes * 60000)
@@ -1416,7 +1416,7 @@ Item {
                     text: root.customDelayText
                     onTextEdited: root.customDelayText = text
                     focus: root.customDelayEditing
-                    validator: IntValidator { bottom: 1; top: 60 }
+                    validator: IntValidator { bottom: 1; top: 1440 }
 
                     Keys.onEscapePressed: {
                       root.customDelayEditing = false

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -725,6 +725,10 @@ Item {
   function beginCustomDelay() {
     root.customDelayText = root.keepDisplayOn ? "" : String(Math.max(1, Math.round(root.blankDelay / 60000)))
     root.customDelayEditing = true
+    Qt.callLater(function() {
+      customDelayInput.forceActiveFocus()
+      customDelayInput.selectAll()
+    })
   }
 
   function commitCustomDelay() {
@@ -734,6 +738,7 @@ Item {
     root.service.setKeepDisplayOn(false)
     root.service.setBlankDelay(minutes * 60000)
     root.customDelayEditing = false
+    keyCatcher.forceActiveFocus()
   }
 
   function customizeSelected() {
@@ -854,13 +859,14 @@ Item {
       // Embedded lock previews can pull keyboard focus; reclaim it whenever
       // it drifts, except while a real editor field wants it.
       onActiveFocusChanged: {
-        if (!activeFocus && root.opened && root.bootEditing.length === 0 && !root.editing)
+        if (!activeFocus && root.opened && root.bootEditing.length === 0 && !root.editing && !root.customDelayEditing)
           Qt.callLater(function() { keyCatcher.forceActiveFocus() })
       }
       Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape) { root.handleEscape(); event.accepted = true; return }
         if (root.editing) return
         if (root.bootEditing.length > 0) return
+        if (root.customDelayEditing) return
         if (root.mainTab !== "styling" && root.mainTab !== "animation") {
           if (event.key === Qt.Key_U) { root.toggleSettings("settings"); event.accepted = true }
           else if (event.key === Qt.Key_B) { root.toggleSettings("boot"); event.accepted = true }
@@ -1410,7 +1416,10 @@ Item {
                     focus: root.customDelayEditing
                     validator: IntValidator { bottom: 1; top: 60 }
 
-                    Keys.onEscapePressed: root.customDelayEditing = false
+                    Keys.onEscapePressed: {
+                      root.customDelayEditing = false
+                      keyCatcher.forceActiveFocus()
+                    }
                     Keys.onReturnPressed: root.commitCustomDelay()
                   }
                 }

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -76,6 +76,7 @@ Item {
   readonly property var unlockDurations: [200, 300, 400, 600, 800]
   readonly property string unlockAnimation: service ? service.unlockAnimation : "none"
   readonly property int unlockDuration: service ? service.unlockDuration : 400
+  readonly property bool keepDisplayOn: service ? service.keepDisplayOn : false
   readonly property string unlockLabel: {
     for (var i = 0; i < unlockOptions.length; i++)
       if (unlockOptions[i].id === unlockAnimation) return unlockOptions[i].name
@@ -705,6 +706,10 @@ Item {
     if (root.service) root.service.setUnlockDuration(ms)
   }
 
+  function toggleKeepDisplayOn() {
+    if (root.service) root.service.setKeepDisplayOn(!root.keepDisplayOn)
+  }
+
   function customizeSelected() {
     if (!root.selectedDesign || !root.service) return
     if (root.selectedDesign.path) { openEditor(root.selectedDesign); return }
@@ -1280,6 +1285,61 @@ Item {
 
               Text {
                 text: "The desktop opens on the frame the clip stopped on, set with omarchy-theme-bg-set."
+                color: root.muted
+                font.family: root.fontFamily
+                font.pixelSize: Style.font.caption
+              }
+
+              // Keep the display powered while locked: skips the five-second
+              // DPMS-off entirely, so video designs keep playing and slow
+              // monitors are never re-blanked mid-wake.
+              Rectangle {
+                width: keepDisplayRow.implicitWidth + Style.space(8)
+                height: Style.space(30)
+                color: "transparent"
+
+                Row {
+                  id: keepDisplayRow
+                  anchors.verticalCenter: parent.verticalCenter
+                  spacing: Style.space(8)
+
+                  Rectangle {
+                    anchors.verticalCenter: parent.verticalCenter
+                    width: Style.space(18)
+                    height: Style.space(18)
+                    radius: root.cornerRadius
+                    color: root.keepDisplayOn ? root.accent : "transparent"
+                    border.width: Math.max(1, Style.space(2))
+                    border.color: root.keepDisplayOn ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.4)
+
+                    Text {
+                      anchors.centerIn: parent
+                      visible: root.keepDisplayOn
+                      text: "✓"
+                      color: Color.background
+                      font.pixelSize: Style.font.caption
+                      font.weight: Font.Bold
+                    }
+                  }
+
+                  Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    text: "Keep the display on while locked"
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+                }
+
+                MouseArea {
+                  anchors.fill: parent
+                  anchors.margins: -Style.space(4)
+                  onClicked: root.toggleKeepDisplayOn()
+                }
+              }
+
+              Text {
+                text: "Lock screen stays lit: no DPMS-off, video designs keep playing."
                 color: root.muted
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -77,6 +77,7 @@ Item {
   readonly property string unlockAnimation: service ? service.unlockAnimation : "none"
   readonly property int unlockDuration: service ? service.unlockDuration : 400
   readonly property bool keepDisplayOn: service ? service.keepDisplayOn : false
+  readonly property int blankDelay: service ? service.blankDelay : 5000
   readonly property string unlockLabel: {
     for (var i = 0; i < unlockOptions.length; i++)
       if (unlockOptions[i].id === unlockAnimation) return unlockOptions[i].name
@@ -706,8 +707,14 @@ Item {
     if (root.service) root.service.setUnlockDuration(ms)
   }
 
-  function toggleKeepDisplayOn() {
-    if (root.service) root.service.setKeepDisplayOn(!root.keepDisplayOn)
+  function setBlankAfter(ms) {
+    if (!root.service) return
+    if (ms === 0) {
+      root.service.setKeepDisplayOn(true)
+      return
+    }
+    root.service.setKeepDisplayOn(false)
+    root.service.setBlankDelay(ms)
   }
 
   function customizeSelected() {
@@ -1290,56 +1297,65 @@ Item {
                 font.pixelSize: Style.font.caption
               }
 
-              // Keep the display powered while locked: skips the five-second
-              // DPMS-off entirely, so video designs keep playing and slow
-              // monitors are never re-blanked mid-wake.
-              Rectangle {
-                width: keepDisplayRow.implicitWidth + Style.space(8)
-                height: Style.space(30)
-                color: "transparent"
+              // How long the lock screen stays lit before the display blanks.
+              // Never keeps it powered for the whole lock: video designs keep
+              // playing and slow monitors are never re-blanked mid-wake.
+              Row {
+                visible: true
+                spacing: Style.space(6)
 
-                Row {
-                  id: keepDisplayRow
+                Text {
                   anchors.verticalCenter: parent.verticalCenter
-                  spacing: Style.space(8)
-
-                  Rectangle {
-                    anchors.verticalCenter: parent.verticalCenter
-                    width: Style.space(18)
-                    height: Style.space(18)
-                    radius: root.cornerRadius
-                    color: root.keepDisplayOn ? root.accent : "transparent"
-                    border.width: Math.max(1, Style.space(2))
-                    border.color: root.keepDisplayOn ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.4)
-
-                    Text {
-                      anchors.centerIn: parent
-                      visible: root.keepDisplayOn
-                      text: "✓"
-                      color: Color.background
-                      font.pixelSize: Style.font.caption
-                      font.weight: Font.Bold
-                    }
-                  }
-
-                  Text {
-                    anchors.verticalCenter: parent.verticalCenter
-                    text: "Keep the display on while locked"
-                    color: root.foreground
-                    font.family: root.fontFamily
-                    font.pixelSize: Style.font.caption
-                  }
+                  text: "Blank the display after"
+                  color: root.muted
+                  font.family: root.fontFamily
+                  font.pixelSize: Style.font.caption
                 }
 
-                MouseArea {
-                  anchors.fill: parent
-                  anchors.margins: -Style.space(4)
-                  onClicked: root.toggleKeepDisplayOn()
+                Repeater {
+                  model: [
+                    { ms: 5000, name: "5s" },
+                    { ms: 15000, name: "15s" },
+                    { ms: 30000, name: "30s" },
+                    { ms: 60000, name: "1m" },
+                    { ms: 300000, name: "5m" },
+                    { ms: 0, name: "Never" }
+                  ]
+                  Rectangle {
+                    id: blankChip
+                    required property var modelData
+                    readonly property bool current: modelData.ms === 0 ? root.keepDisplayOn
+                                                                       : (!root.keepDisplayOn && root.blankDelay === modelData.ms)
+                    width: blankChipLabel.implicitWidth + Style.space(18)
+                    height: Style.space(26)
+                    radius: root.cornerRadius
+                    color: current ? root.accent : Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, blankChipArea.containsMouse ? 0.12 : 0.06)
+                    Behavior on color { ColorAnimation { duration: 100 } }
+
+                    Text {
+                      id: blankChipLabel
+                      anchors.centerIn: parent
+                      text: blankChip.modelData.name
+                      color: blankChip.current ? Color.background : root.foreground
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.weight: blankChip.current ? Font.DemiBold : Font.Normal
+                    }
+
+                    MouseArea {
+                      id: blankChipArea
+                      anchors.fill: parent
+                      hoverEnabled: true
+                      onClicked: root.setBlankAfter(blankChip.modelData.ms)
+                    }
+                  }
                 }
               }
 
               Text {
-                text: "Lock screen stays lit: no DPMS-off, video designs keep playing."
+                text: root.keepDisplayOn
+                      ? "The lock screen stays lit for the whole lock: video designs keep playing."
+                      : "The lock screen stays lit, then the display powers down."
                 color: root.muted
                 font.family: root.fontFamily
                 font.pixelSize: Style.font.caption

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -78,6 +78,10 @@ Item {
   readonly property int unlockDuration: service ? service.unlockDuration : 400
   readonly property bool keepDisplayOn: service ? service.keepDisplayOn : false
   readonly property int blankDelay: service ? service.blankDelay : 5000
+  readonly property var blankPresets: [5000, 15000, 30000, 60000, 300000]
+  property bool customDelayEditing: false
+  property string customDelayText: ""
+  readonly property bool blankDelayIsCustom: !root.keepDisplayOn && root.blankPresets.indexOf(root.blankDelay) === -1
   readonly property string unlockLabel: {
     for (var i = 0; i < unlockOptions.length; i++)
       if (unlockOptions[i].id === unlockAnimation) return unlockOptions[i].name
@@ -709,12 +713,27 @@ Item {
 
   function setBlankAfter(ms) {
     if (!root.service) return
+    root.customDelayEditing = false
     if (ms === 0) {
       root.service.setKeepDisplayOn(true)
       return
     }
     root.service.setKeepDisplayOn(false)
     root.service.setBlankDelay(ms)
+  }
+
+  function beginCustomDelay() {
+    root.customDelayText = root.keepDisplayOn ? "" : String(Math.round(root.blankDelay / 1000))
+    root.customDelayEditing = true
+  }
+
+  function commitCustomDelay() {
+    var seconds = Math.round(Number(root.customDelayText))
+    if (!isFinite(seconds) || seconds < 1 || seconds > 3600) return
+    if (!root.service) return
+    root.service.setKeepDisplayOn(false)
+    root.service.setBlankDelay(seconds * 1000)
+    root.customDelayEditing = false
   }
 
   function customizeSelected() {
@@ -1319,12 +1338,14 @@ Item {
                     { ms: 30000, name: "30s" },
                     { ms: 60000, name: "1m" },
                     { ms: 300000, name: "5m" },
+                    { ms: -1, name: "Custom" },
                     { ms: 0, name: "Never" }
                   ]
                   Rectangle {
                     id: blankChip
                     required property var modelData
                     readonly property bool current: modelData.ms === 0 ? root.keepDisplayOn
+                                                                       : modelData.ms === -1 ? root.blankDelayIsCustom
                                                                        : (!root.keepDisplayOn && root.blankDelay === modelData.ms)
                     width: blankChipLabel.implicitWidth + Style.space(18)
                     height: Style.space(26)
@@ -1346,8 +1367,49 @@ Item {
                       id: blankChipArea
                       anchors.fill: parent
                       hoverEnabled: true
-                      onClicked: root.setBlankAfter(blankChip.modelData.ms)
+                      onClicked: {
+                        if (blankChip.modelData.ms === -1) root.beginCustomDelay()
+                        else root.setBlankAfter(blankChip.modelData.ms)
+                      }
                     }
+                  }
+                }
+
+                Rectangle {
+                  visible: root.customDelayEditing
+                  width: Style.space(64)
+                  height: Style.space(26)
+                  radius: root.cornerRadius
+                  color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
+                  border.width: Math.max(1, Style.space(2))
+                  border.color: root.accent
+
+                  TextInput {
+                    id: customDelayInput
+                    anchors.fill: parent
+                    anchors.leftMargin: Style.space(8)
+                    anchors.rightMargin: Style.space(8)
+                    verticalAlignment: TextInput.AlignVCenter
+                    color: root.foreground
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                    text: root.customDelayText
+                    onTextEdited: root.customDelayText = text
+                    focus: root.customDelayEditing
+                    validator: IntValidator { bottom: 1; top: 3600 }
+
+                    Text {
+                      anchors.verticalCenter: parent.verticalCenter
+                      anchors.left: parent.right
+                      anchors.leftMargin: Style.space(4)
+                      text: "s, Enter"
+                      color: root.muted
+                      font.family: root.fontFamily
+                      font.pixelSize: Style.font.caption
+                    }
+
+                    Keys.onEscapePressed: root.customDelayEditing = false
+                    Keys.onReturnPressed: root.commitCustomDelay()
                   }
                 }
               }

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -723,16 +723,16 @@ Item {
   }
 
   function beginCustomDelay() {
-    root.customDelayText = root.keepDisplayOn ? "" : String(Math.round(root.blankDelay / 1000))
+    root.customDelayText = root.keepDisplayOn ? "" : String(Math.max(1, Math.round(root.blankDelay / 60000)))
     root.customDelayEditing = true
   }
 
   function commitCustomDelay() {
-    var seconds = Math.round(Number(root.customDelayText))
-    if (!isFinite(seconds) || seconds < 1 || seconds > 3600) return
+    var minutes = Math.round(Number(root.customDelayText))
+    if (!isFinite(minutes) || minutes < 1 || minutes > 60) return
     if (!root.service) return
     root.service.setKeepDisplayOn(false)
-    root.service.setBlankDelay(seconds * 1000)
+    root.service.setBlankDelay(minutes * 60000)
     root.customDelayEditing = false
   }
 
@@ -1377,18 +1377,30 @@ Item {
 
                 Rectangle {
                   visible: root.customDelayEditing
-                  width: Style.space(64)
+                  width: Style.space(110)
                   height: Style.space(26)
                   radius: root.cornerRadius
                   color: Qt.rgba(root.foreground.r, root.foreground.g, root.foreground.b, 0.06)
                   border.width: Math.max(1, Style.space(2))
                   border.color: root.accent
 
+                  // The unit hint lives inside the box, right-aligned, and the
+                  // input reserves its width so typed digits never run under it.
+                  Text {
+                    anchors.verticalCenter: parent.verticalCenter
+                    anchors.right: parent.right
+                    anchors.rightMargin: Style.space(8)
+                    text: "m, Enter"
+                    color: root.muted
+                    font.family: root.fontFamily
+                    font.pixelSize: Style.font.caption
+                  }
+
                   TextInput {
                     id: customDelayInput
                     anchors.fill: parent
                     anchors.leftMargin: Style.space(8)
-                    anchors.rightMargin: Style.space(8)
+                    anchors.rightMargin: Style.space(52)
                     verticalAlignment: TextInput.AlignVCenter
                     color: root.foreground
                     font.family: root.fontFamily
@@ -1396,17 +1408,7 @@ Item {
                     text: root.customDelayText
                     onTextEdited: root.customDelayText = text
                     focus: root.customDelayEditing
-                    validator: IntValidator { bottom: 1; top: 3600 }
-
-                    Text {
-                      anchors.verticalCenter: parent.verticalCenter
-                      anchors.left: parent.right
-                      anchors.leftMargin: Style.space(4)
-                      text: "s, Enter"
-                      color: root.muted
-                      font.family: root.fontFamily
-                      font.pixelSize: Style.font.caption
-                    }
+                    validator: IntValidator { bottom: 1; top: 60 }
 
                     Keys.onEscapePressed: root.customDelayEditing = false
                     Keys.onReturnPressed: root.commitCustomDelay()

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -1362,7 +1362,9 @@ Item {
                     Text {
                       id: blankChipLabel
                       anchors.centerIn: parent
-                      text: blankChip.modelData.name
+                      text: blankChip.modelData.ms === -1 && root.blankDelayIsCustom
+                            ? "Custom (" + Math.round(root.blankDelay / 60000) + "m)"
+                            : blankChip.modelData.name
                       color: blankChip.current ? Color.background : root.foreground
                       font.family: root.fontFamily
                       font.pixelSize: Style.font.caption

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ the plugin entry in `~/.config/omarchy/shell.json`.
 
 By default the lock screen DPMS-offs the display five seconds after locking. The Settings tab has
 a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, Custom, or Never. Custom takes minutes
-(1 to 60) typed into an inline field. By hand: `omarchy-shell lock setBlankDelay 30000`, or
+(1 to 1440) typed into an inline field. By hand: `omarchy-shell lock setBlankDelay 30000`, or
 `setKeepDisplayOn true` for Never.
 
 **Never** keeps the lock screen lit for the whole lock: video designs keep playing, and slow

--- a/README.md
+++ b/README.md
@@ -103,13 +103,14 @@ instead, and the fade goes straight into it.
 The selected design, the avatar, the unlock animation and the boot screen setting are saved on
 the plugin entry in `~/.config/omarchy/shell.json`.
 
-### Keep the display on while locked
+### Blank the display after
 
-By default the lock screen DPMS-offs the display five seconds after locking. The "Keep the
-display on while locked" checkbox in the explorer's Settings tab (or
-`omarchy-shell lock setKeepDisplayOn true`) skips that entirely: the lock screen stays lit, video
-designs keep playing, and slow monitors are never re-blanked mid-wake. The keyboard, mouse and
-fingerprint still wake nothing because nothing needs waking — type your password as usual.
+By default the lock screen DPMS-offs the display five seconds after locking. The Settings tab has
+a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, or Never (`omarchy-shell lock
+setBlankDelay 30000`, or `setKeepDisplayOn true` for Never).
+
+**Never** keeps the lock screen lit for the whole lock: video designs keep playing, and slow
+monitors are never re-blanked mid-wake on resume — the display was never off to begin with.
 
 With no avatar set, the first of `~/.config/omarchy/lock-avatar.{png,jpg,jpeg,webp}`, `~/.face`,
 `~/.face.icon` and `/var/lib/AccountsService/icons/$USER` is used, so an existing profile picture

--- a/README.md
+++ b/README.md
@@ -103,6 +103,14 @@ instead, and the fade goes straight into it.
 The selected design, the avatar, the unlock animation and the boot screen setting are saved on
 the plugin entry in `~/.config/omarchy/shell.json`.
 
+### Keep the display on while locked
+
+By default the lock screen DPMS-offs the display five seconds after locking. The "Keep the
+display on while locked" checkbox in the explorer's Settings tab (or
+`omarchy-shell lock setKeepDisplayOn true`) skips that entirely: the lock screen stays lit, video
+designs keep playing, and slow monitors are never re-blanked mid-wake. The keyboard, mouse and
+fingerprint still wake nothing because nothing needs waking — type your password as usual.
+
 With no avatar set, the first of `~/.config/omarchy/lock-avatar.{png,jpg,jpeg,webp}`, `~/.face`,
 `~/.face.icon` and `/var/lib/AccountsService/icons/$USER` is used, so an existing profile picture
 shows up on its own.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,9 @@ the plugin entry in `~/.config/omarchy/shell.json`.
 ### Blank the display after
 
 By default the lock screen DPMS-offs the display five seconds after locking. The Settings tab has
-a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, or Never (`omarchy-shell lock
-setBlankDelay 30000`, or `setKeepDisplayOn true` for Never).
+a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, Custom, or Never. Custom takes seconds
+(1 to 3600) typed into an inline field. By hand: `omarchy-shell lock setBlankDelay 30000`, or
+`setKeepDisplayOn true` for Never.
 
 **Never** keeps the lock screen lit for the whole lock: video designs keep playing, and slow
 monitors are never re-blanked mid-wake on resume — the display was never off to begin with.

--- a/README.md
+++ b/README.md
@@ -106,8 +106,8 @@ the plugin entry in `~/.config/omarchy/shell.json`.
 ### Blank the display after
 
 By default the lock screen DPMS-offs the display five seconds after locking. The Settings tab has
-a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, Custom, or Never. Custom takes seconds
-(1 to 3600) typed into an inline field. By hand: `omarchy-shell lock setBlankDelay 30000`, or
+a "Blank the display after" row — 5s, 15s, 30s, 1m, 5m, Custom, or Never. Custom takes minutes
+(1 to 60) typed into an inline field. By hand: `omarchy-shell lock setBlankDelay 30000`, or
 `setKeepDisplayOn true` for Never.
 
 **Never** keeps the lock screen lit for the whole lock: video designs keep playing, and slow

--- a/Service.qml
+++ b/Service.qml
@@ -99,7 +99,7 @@ Item {
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
       if (entry && String(entry.id || "") === pluginId && entry.blankMs !== undefined)
-        return Math.max(1000, Math.min(3600000, Number(entry.blankMs) || defaultBlankDelay))
+        return Math.max(1000, Math.min(86400000, Number(entry.blankMs) || defaultBlankDelay))
     }
     return defaultBlankDelay
   }
@@ -296,7 +296,7 @@ Item {
   function setBlankDelay(ms) {
     var text = String(ms === undefined ? "" : ms).trim()
     var value = Math.round(Number(text))
-    if (text.length === 0 || !isFinite(value) || value < 1000 || value > 3600000) return false
+    if (text.length === 0 || !isFinite(value) || value < 1000 || value > 86400000) return false
 
     blankDelayOverride = value
     if (shell && typeof shell.updateEntryInline === "function") {

--- a/Service.qml
+++ b/Service.qml
@@ -87,6 +87,24 @@ Item {
   readonly property int unlockDuration: unlockDurationOverride >= 0 ? unlockDurationOverride : configuredUnlockDuration
   readonly property bool unlockAnimated: unlockAnimation !== "none" && unlockDuration > 0
 
+  // How long the unlock screen stays lit before the display is blanked. The
+  // session is locked before every suspend, so on a machine that sleeps this
+  // delay is what the user sees on resume: too short and the screen goes dark
+  // before there is time to type. Saved on the plugin entry as `blankMs`.
+  readonly property int defaultBlankDelay: 5000
+  property int blankDelayOverride: -1
+  readonly property int configuredBlankDelay: {
+    var cfg = shell ? shell.shellConfig : null
+    var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
+    for (var i = 0; i < list.length; i++) {
+      var entry = list[i]
+      if (entry && String(entry.id || "") === pluginId && entry.blankMs !== undefined)
+        return Math.max(1000, Math.min(3600000, Number(entry.blankMs) || defaultBlankDelay))
+    }
+    return defaultBlankDelay
+  }
+  readonly property int blankDelay: blankDelayOverride >= 0 ? blankDelayOverride : configuredBlankDelay
+
   // Avatar picture for the designs that show the user. The chosen path lives on
   // the plugin entry in shell.json; "none" there means the user cleared it and
   // wants the initial back, an empty setting falls back to the usual dotfiles.
@@ -1908,7 +1926,7 @@ echo "$out"
 
   Timer {
     id: idleBlankTimer
-    interval: 5000
+    interval: root.blankDelay
     repeat: false
     property double armedAt: 0
     onTriggered: {
@@ -2039,6 +2057,7 @@ echo "$out"
         unlock: root.unlockAnimation,
         unlockMs: root.unlockDuration,
         unlockAnimated: root.unlockAnimated,
+        blankMs: root.blankDelay,
         unlocking: root.unlocking,
         clipDesign: root.designHasClip,
         clipUnlocking: root.clipUnlocking,

--- a/Service.qml
+++ b/Service.qml
@@ -293,6 +293,22 @@ Item {
     return true
   }
 
+  function setBlankDelay(ms) {
+    var text = String(ms === undefined ? "" : ms).trim()
+    var value = Math.round(Number(text))
+    if (text.length === 0 || !isFinite(value) || value < 1000 || value > 3600000) return false
+
+    blankDelayOverride = value
+    if (shell && typeof shell.updateEntryInline === "function") {
+      var current = pluginEntry()
+      if (value === defaultBlankDelay) delete current.blankMs
+      else current.blankMs = value
+      shell.updateEntryInline(pluginId, current)
+    }
+    logEvent("blank-ms=" + value)
+    return true
+  }
+
   function setKeepDisplayOn(on) {
     var value = on === true || on === 1 || on === "true"
     keepDisplayOnOverride = value ? 1 : 0
@@ -2088,6 +2104,7 @@ echo "$out"
         unlockMs: root.unlockDuration,
         unlockAnimated: root.unlockAnimated,
         blankMs: root.blankDelay,
+        keepDisplayOn: root.keepDisplayOn,
         unlocking: root.unlocking,
         clipDesign: root.designHasClip,
         clipUnlocking: root.clipUnlocking,
@@ -2133,6 +2150,10 @@ echo "$out"
 
     function setKeepDisplayOn(value: string): string {
       return root.setKeepDisplayOn(value) ? "ok" : "invalid-value"
+    }
+
+    function setBlankDelay(value: string): string {
+      return root.setBlankDelay(value) ? "ok" : "invalid-value"
     }
 
     function boot(): string {

--- a/Service.qml
+++ b/Service.qml
@@ -105,6 +105,22 @@ Item {
   }
   readonly property int blankDelay: blankDelayOverride >= 0 ? blankDelayOverride : configuredBlankDelay
 
+  // When true the display stays powered while locked: the DPMS-off is skipped
+  // entirely, so video designs keep playing and slow monitors are never
+  // re-blanked. Takes precedence over blankDelay. Lives on the plugin entry
+  // in shell.json.
+  property int keepDisplayOnOverride: -1
+  readonly property bool configuredKeepDisplayOn: {
+    var cfg = shell ? shell.shellConfig : null
+    var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
+    for (var i = 0; i < list.length; i++) {
+      var entry = list[i]
+      if (entry && String(entry.id || "") === pluginId) return entry.keepDisplayOn === true
+    }
+    return false
+  }
+  readonly property bool keepDisplayOn: keepDisplayOnOverride >= 0 ? keepDisplayOnOverride === 1 : configuredKeepDisplayOn
+
   // Avatar picture for the designs that show the user. The chosen path lives on
   // the plugin entry in shell.json; "none" there means the user cleared it and
   // wants the initial back, an empty setting falls back to the usual dotfiles.
@@ -274,6 +290,19 @@ Item {
       shell.updateEntryInline(pluginId, current)
     }
     logEvent("unlock-ms=" + value)
+    return true
+  }
+
+  function setKeepDisplayOn(on) {
+    var value = on === true || on === 1 || on === "true"
+    keepDisplayOnOverride = value ? 1 : 0
+    if (shell && typeof shell.updateEntryInline === "function") {
+      var current = pluginEntry()
+      if (!value) delete current.keepDisplayOn
+      else current.keepDisplayOn = true
+      shell.updateEntryInline(pluginId, current)
+    }
+    logEvent("keep-display-on=" + value)
     return true
   }
 
@@ -1561,6 +1590,7 @@ echo "$out"
   }
 
   function runBlank() {
+    if (keepDisplayOn) return
     screenBlanked = true
     if (!blankProcess.running) blankProcess.running = true
   }
@@ -2099,6 +2129,10 @@ echo "$out"
 
     function setDesign(id: string): string {
       return root.setDesign(id) ? "ok" : "unknown-design"
+    }
+
+    function setKeepDisplayOn(value: string): string {
+      return root.setKeepDisplayOn(value) ? "ok" : "invalid-value"
     }
 
     function boot(): string {


### PR DESCRIPTION
Stacked on #10 (`blankMs`). that PR makes the blank delay tunable. this adds
the escape hatch past it and the UI that drives both.

### Motivation

The 5-second DPMS-off after locking has three failure modes that share one root:

1. **Video designs go dark.** `videoPlaying: locked && !screenBlanked` means a
   Storm/River/Eyes lock screen plays for five seconds, then the screen powers
   down. the design you picked is only visible during unlock.
2. **Slow monitors race the blank.** Panels with slow DPMS resync (6K/DSC) can
   take longer than the delay to wake, so the same re-blank-on-wake race reported
   in omacom/omarchy#7749 and #7399. A screen that never blanks can't re-blank.
3. **Always-lit lock screens**, clock + avatar visible across the room,
   smart-display style.

### What this adds

- `keepDisplayOn` boolean on the plugin entry (default `false`, zero behavior
  change). `runBlank()` returns early when set, so the wake/arm/suspend-resume
  machinery is untouched.
- `setBlankDelay` setter + IPC (`omarchy-shell lock setBlankDelay 30000`). this is
  the UI-facing half of #10's `blankMs` plumbing.
- Explorer Settings tab: a single "Blank the display after" row 
  `5s / 15s / 30s / 1m / 5m / Custom / Never`. Times write `blankMs`; "Never" writes
  `keepDisplayOn`. Custom opens a small inline input in minutes
  (1 to 1440), so nobody is stuck with the presets. Status JSON now reports `keepDisplayOn` alongside `blankMs`.
- The Custom chip shows its set value once active (`Custom (4m)`), and the field
  holds keyboard focus while open, using the same exemption the design editor
  has from the explorer's keyCatcher.
- README section for both settings.

### Notes for review

- Default-off: with no `keepDisplayOn` in the entry, behavior is identical to
  #10's alone.
- The two settings compose: `keepDisplayOn` wins over `blankMs` when both are
  set. the UI keeps them consistent (choosing a time clears Never and
  vice versa).
- One merged hunk with #10 (settings block after `unlockAnimated`). this
  branch is rebased on top of #10, so it merges clean whenever that lands.
- this branch raises the blankMs ceiling from 60 to 1440 minutes, since a
  240m lock screen is exactly the kind of delay the Custom field invites.
  easy to drop back to 60 if you would rather keep #10's limit strict.
- 3 files changed, 218 insertions(+), 2 deletions(-). the files are
  Service.qml, Explorer.qml and README.md.
