### PR TITLE
Add a visual designer for building lock screens

### DIFF
--- a/Designer.js
+++ b/Designer.js
@@ -1,0 +1,649 @@
+.pragma library
+
+// Model, palette and code generator for the visual designer.
+//
+// A designer layout is a plain object:
+//   { v: 1, name: "My Layout", nodes: [ node, ... ] }
+// and a node is:
+//   { id: "n3", kind: "clock", anchor: "center", dx: 0, dy: -160,
+//     w: 0, h: 0, spec: { ... } }
+//
+// dx/dy are signed pixel offsets from the anchor point, positive right/down,
+// in the screen's own coordinates. w/h of 0 mean "size yourself from your
+// content". The layout is written into the design file as a single comment
+// line (MARKER below) and the QML underneath is generated from it, so the
+// designer never has to parse QML back.
+
+var MARKER = "designer:1:"
+var VERSION = 1
+var DEFAULT_NAME = "My Layout"
+
+// ------------------------------------------------------------------ anchors
+
+var ANCHORS = [
+  "topLeft", "top", "topRight",
+  "left", "center", "right",
+  "bottomLeft", "bottom", "bottomRight"
+]
+
+function anchorCol(anchor) {
+  if (anchor === "topLeft" || anchor === "left" || anchor === "bottomLeft") return 0
+  if (anchor === "topRight" || anchor === "right" || anchor === "bottomRight") return 2
+  return 1
+}
+
+function anchorRow(anchor) {
+  if (anchor === "topLeft" || anchor === "top" || anchor === "topRight") return 0
+  if (anchor === "bottomLeft" || anchor === "bottom" || anchor === "bottomRight") return 2
+  return 1
+}
+
+function anchorFor(col, row) { return ANCHORS[row * 3 + col] }
+
+// The anchor a node dropped at this spot should keep, so it stays where it
+// was put on screens of another size: near an edge it sticks to that edge,
+// in the middle third it rides the center.
+function anchorAt(cx, cy, screenW, screenH) {
+  var col = cx < screenW / 3 ? 0 : (cx > screenW * 2 / 3 ? 2 : 1)
+  var row = cy < screenH / 3 ? 0 : (cy > screenH * 2 / 3 ? 2 : 1)
+  return anchorFor(col, row)
+}
+
+// x of the node's left edge, given its offset and size.
+function xFor(node, w, screenW) {
+  var col = anchorCol(node.anchor)
+  if (col === 0) return node.dx
+  if (col === 2) return screenW + node.dx - w
+  return (screenW - w) / 2 + node.dx
+}
+
+function yFor(node, h, screenH) {
+  var row = anchorRow(node.anchor)
+  if (row === 0) return node.dy
+  if (row === 2) return screenH + node.dy - h
+  return (screenH - h) / 2 + node.dy
+}
+
+// The inverse: the offset that puts the node's left/top edge at x/y.
+function dxFor(anchor, x, w, screenW) {
+  var col = anchorCol(anchor)
+  if (col === 0) return x
+  if (col === 2) return x + w - screenW
+  return x - (screenW - w) / 2
+}
+
+function dyFor(anchor, y, h, screenH) {
+  var row = anchorRow(anchor)
+  if (row === 0) return y
+  if (row === 2) return y + h - screenH
+  return y - (screenH - h) / 2
+}
+
+// Re-anchor without moving: keep the pixels, change the rule.
+function reanchor(node, anchor, w, h, screenW, screenH) {
+  var x = xFor(node, w, screenW)
+  var y = yFor(node, h, screenH)
+  node.anchor = anchor
+  node.dx = Math.round(dxFor(anchor, x, w, screenW))
+  node.dy = Math.round(dyFor(anchor, y, h, screenH))
+  return node
+}
+
+// ------------------------------------------------------------------- colors
+
+// Color choices are theme roles, so a design keeps working when the theme
+// changes. A literal #rrggbb is allowed too.
+var COLOR_ROLES = [
+  { id: "text", name: "Text" },
+  { id: "accent", name: "Accent" },
+  { id: "error", name: "Error" },
+  { id: "placeholder", name: "Muted" },
+  { id: "surface", name: "Surface" },
+  { id: "background", name: "Background" },
+  { id: "black", name: "Black" },
+  { id: "white", name: "White" }
+]
+
+// -------------------------------------------------------------------- kinds
+
+var WEIGHTS = [
+  { id: 300, name: "Light" },
+  { id: 400, name: "Regular" },
+  { id: 500, name: "Medium" },
+  { id: 600, name: "DemiBold" },
+  { id: 700, name: "Bold" }
+]
+
+var ALIGNMENTS = [
+  { id: "left", name: "Left" },
+  { id: "center", name: "Center" },
+  { id: "right", name: "Right" }
+]
+
+function textFields(extra) {
+  var base = [
+    { key: "size", type: "number", label: "Font size", min: 6, max: 400, step: 2 },
+    { key: "weight", type: "choice", label: "Weight", options: WEIGHTS },
+    { key: "color", type: "color", label: "Color" },
+    { key: "alpha", type: "slider", label: "Opacity", min: 0.05, max: 1, step: 0.05 },
+    { key: "spacing", type: "number", label: "Letter spacing", min: -10, max: 40, step: 1 },
+    { key: "align", type: "choice", label: "Align", options: ALIGNMENTS },
+    { key: "caps", type: "bool", label: "Uppercase" },
+    { key: "shadow", type: "bool", label: "Drop shadow" }
+  ]
+  return (extra || []).concat(base)
+}
+
+// Every draggable piece. `group` buckets them in the palette, `sized` says
+// whether dragging a corner handle should resize it, `fill` marks the
+// full-screen backgrounds.
+var KINDS = {
+  wallpaper: {
+    name: "Wallpaper", group: "Background", glyph: "󰸉",
+    hint: "The desktop wallpaper, blurred and dimmed",
+    fill: true,
+    spec: { blur: 0.85, dim: 0.08, vignette: true },
+    fields: [
+      { key: "blur", type: "slider", label: "Blur", min: 0, max: 1, step: 0.05 },
+      { key: "dim", type: "slider", label: "Dim", min: 0, max: 0.9, step: 0.05 },
+      { key: "vignette", type: "bool", label: "Vignette" }
+    ]
+  },
+  video: {
+    name: "Video", group: "Background", glyph: "󰕧",
+    hint: "The looping video set with lock setVideo",
+    fill: true,
+    spec: { dim: 0.25, vignette: true },
+    fields: [
+      { key: "dim", type: "slider", label: "Dim", min: 0, max: 0.9, step: 0.05 },
+      { key: "vignette", type: "bool", label: "Vignette" }
+    ]
+  },
+  color: {
+    name: "Solid color", group: "Background", glyph: "󰝤",
+    hint: "A flat background, no wallpaper",
+    fill: true,
+    spec: { color: "background", alpha: 1 },
+    fields: [
+      { key: "color", type: "color", label: "Color" },
+      { key: "alpha", type: "slider", label: "Opacity", min: 0.05, max: 1, step: 0.05 }
+    ]
+  },
+
+  clock: {
+    name: "Clock", group: "Text", glyph: "󰅐",
+    hint: "The time, ticking",
+    spec: { format: "HH:mm", size: 120, weight: 600, color: "text", alpha: 1, spacing: -2, align: "center", caps: false, shadow: true },
+    fields: textFields([
+      { key: "format", type: "choice", label: "Format", options: [
+        { id: "HH:mm", name: "13:05" },
+        { id: "H:mm", name: "13:05 (no pad)" },
+        { id: "hh:mm AP", name: "01:05 PM" },
+        { id: "h:mm ap", name: "1:05 pm" },
+        { id: "HH:mm:ss", name: "13:05:42" },
+        { id: "HH", name: "13 (hour only)" },
+        { id: "mm", name: "05 (minute only)" }
+      ] }
+    ])
+  },
+  date: {
+    name: "Date", group: "Text", glyph: "󰃭",
+    hint: "Today's date",
+    spec: { format: "dddd, d MMMM", size: 26, weight: 400, color: "text", alpha: 0.85, spacing: 1, align: "center", caps: false, shadow: true },
+    fields: textFields([
+      { key: "format", type: "choice", label: "Format", options: [
+        { id: "dddd, d MMMM", name: "Monday, 5 May" },
+        { id: "dddd", name: "Monday" },
+        { id: "ddd d MMM", name: "Mon 5 May" },
+        { id: "d MMMM yyyy", name: "5 May 2026" },
+        { id: "yyyy-MM-dd", name: "2026-05-05" },
+        { id: "MMMM", name: "May" }
+      ] }
+    ])
+  },
+  greeting: {
+    name: "Greeting", group: "Text", glyph: "󰀄",
+    hint: "Good morning / afternoon / evening",
+    spec: { withName: true, size: 28, weight: 600, color: "text", alpha: 1, spacing: 0, align: "center", caps: false, shadow: false },
+    fields: textFields([
+      { key: "withName", type: "bool", label: "Add your name" }
+    ])
+  },
+  label: {
+    name: "Text", group: "Text", glyph: "󰊄",
+    hint: "Any words you like",
+    spec: { text: "Locked", size: 22, weight: 400, color: "text", alpha: 0.7, spacing: 1, align: "center", caps: false, shadow: false },
+    fields: textFields([
+      { key: "text", type: "text", label: "Text" }
+    ])
+  },
+  username: {
+    name: "User name", group: "Text", glyph: "󰋦",
+    hint: "Who is logged in",
+    spec: { size: 24, weight: 600, color: "text", alpha: 1, spacing: 0, align: "center", caps: false, shadow: false },
+    fields: textFields()
+  },
+  hostname: {
+    name: "Host name", group: "Text", glyph: "󰒋",
+    hint: "The machine's name",
+    spec: { size: 18, weight: 400, color: "text", alpha: 0.6, spacing: 2, align: "center", caps: true, shadow: false },
+    fields: textFields()
+  },
+  status: {
+    name: "Status line", group: "Text", glyph: "󰀦",
+    hint: "Your hint, and the failure message when a password is wrong",
+    spec: { text: "Enter your password to unlock", size: 16, weight: 400, color: "placeholder", alpha: 1, spacing: 0, align: "center", caps: false, shadow: false, attempts: true },
+    fields: textFields([
+      { key: "text", type: "text", label: "Idle text" },
+      { key: "attempts", type: "bool", label: "Count failed attempts" }
+    ])
+  },
+
+  password: {
+    name: "Password box", group: "Input", glyph: "󰌾",
+    hint: "The normal input box, with the eye and fingerprint hints",
+    sized: true, input: true,
+    w: 400, h: 60,
+    spec: { placeholder: "Enter password", glyph: true, fontScale: 1, align: "center" },
+    fields: [
+      { key: "placeholder", type: "text", label: "Placeholder" },
+      { key: "glyph", type: "bool", label: "Lock glyph" },
+      { key: "fontScale", type: "slider", label: "Text scale", min: 0.6, max: 2, step: 0.1 },
+      { key: "align", type: "choice", label: "Align", options: ALIGNMENTS }
+    ]
+  },
+  dots: {
+    name: "Dots", group: "Input", glyph: "󰇼",
+    hint: "No box, just a dot per character — type anywhere",
+    sized: true, input: true,
+    w: 320, h: 44,
+    spec: { size: 14, gap: 14, color: "text", alpha: 0.9, max: 24 },
+    fields: [
+      { key: "size", type: "number", label: "Dot size", min: 4, max: 48, step: 1 },
+      { key: "gap", type: "number", label: "Gap", min: 2, max: 60, step: 1 },
+      { key: "max", type: "number", label: "Max dots", min: 4, max: 64, step: 1 },
+      { key: "color", type: "color", label: "Color" },
+      { key: "alpha", type: "slider", label: "Opacity", min: 0.1, max: 1, step: 0.05 }
+    ]
+  },
+
+  avatar: {
+    name: "Avatar", group: "Media", glyph: "󰀉",
+    hint: "Your picture, or your initial when there is none",
+    sized: true, square: true,
+    w: 120, h: 120,
+    spec: { borderWidth: 0, borderAlpha: 0.25, shadow: true },
+    fields: [
+      { key: "borderWidth", type: "number", label: "Ring width", min: 0, max: 20, step: 1 },
+      { key: "borderAlpha", type: "slider", label: "Ring opacity", min: 0.05, max: 1, step: 0.05 },
+      { key: "shadow", type: "bool", label: "Drop shadow" }
+    ]
+  },
+  image: {
+    name: "Image", group: "Media", glyph: "󰋩",
+    hint: "A picture file of your own",
+    sized: true,
+    w: 240, h: 160,
+    spec: { path: "", radius: 8, mode: "crop", alpha: 1 },
+    fields: [
+      { key: "path", type: "file", label: "File" },
+      { key: "radius", type: "number", label: "Corner radius", min: 0, max: 200, step: 2 },
+      { key: "mode", type: "choice", label: "Fit", options: [
+        { id: "crop", name: "Fill and crop" },
+        { id: "fit", name: "Fit inside" },
+        { id: "stretch", name: "Stretch" }
+      ] },
+      { key: "alpha", type: "slider", label: "Opacity", min: 0.05, max: 1, step: 0.05 }
+    ]
+  },
+
+  panel: {
+    name: "Panel", group: "Shapes", glyph: "󰝦",
+    hint: "A rounded surface to sit things on",
+    sized: true,
+    w: 460, h: 300,
+    spec: { color: "surface", alpha: 0.55, radius: 20, borderAlpha: 0.12, borderColor: "text", shadow: true },
+    fields: [
+      { key: "color", type: "color", label: "Fill" },
+      { key: "alpha", type: "slider", label: "Fill opacity", min: 0, max: 1, step: 0.05 },
+      { key: "radius", type: "number", label: "Corner radius", min: 0, max: 200, step: 2 },
+      { key: "borderColor", type: "color", label: "Border" },
+      { key: "borderAlpha", type: "slider", label: "Border opacity", min: 0, max: 1, step: 0.02 },
+      { key: "shadow", type: "bool", label: "Drop shadow" }
+    ]
+  },
+  line: {
+    name: "Divider", group: "Shapes", glyph: "󰧟",
+    hint: "A hairline rule",
+    sized: true,
+    w: 320, h: 1,
+    spec: { color: "text", alpha: 0.2 },
+    fields: [
+      { key: "color", type: "color", label: "Color" },
+      { key: "alpha", type: "slider", label: "Opacity", min: 0.02, max: 1, step: 0.02 }
+    ]
+  },
+
+  custom: {
+    name: "Custom QML", group: "Yours", glyph: "󰘦",
+    hint: "Write the QML yourself — lock.now, lock.userName and the rest are in scope",
+    sized: true,
+    w: 300, h: 120,
+    spec: { qml: 'Text {\n  anchors.centerIn: parent\n  text: Qt.formatDate(lock.now, "dddd")\n  color: Color.lock.text\n  font.family: Style.font.family\n  font.pixelSize: 32\n}' },
+    fields: [
+      { key: "qml", type: "code", label: "QML" }
+    ]
+  }
+}
+
+var GROUPS = ["Background", "Text", "Input", "Media", "Shapes", "Yours"]
+
+function kind(id) { return KINDS[id] || null }
+
+function kindName(id) { return KINDS[id] ? KINDS[id].name : id }
+
+function paletteFor(group) {
+  var out = []
+  for (var id in KINDS) if (KINDS[id].group === group) out.push({ id: id, kind: KINDS[id] })
+  out.sort(function(a, b) { return a.kind.name.localeCompare(b.kind.name) })
+  return out
+}
+
+function isFill(node) { return !!(node && KINDS[node.kind] && KINDS[node.kind].fill) }
+function isInput(node) { return !!(node && KINDS[node.kind] && KINDS[node.kind].input) }
+function isSized(node) { return !!(node && KINDS[node.kind] && KINDS[node.kind].sized) }
+function isSquare(node) { return !!(node && KINDS[node.kind] && KINDS[node.kind].square) }
+
+function clone(v) { return JSON.parse(JSON.stringify(v)) }
+
+// ---------------------------------------------------------------- documents
+
+function newNode(kindId, id) {
+  var k = KINDS[kindId]
+  if (!k) return null
+  return {
+    id: id,
+    kind: kindId,
+    anchor: "center",
+    dx: 0,
+    dy: 0,
+    w: k.w || 0,
+    h: k.h || 0,
+    spec: clone(k.spec || {})
+  }
+}
+
+function nextId(doc) {
+  var n = 1
+  var used = {}
+  for (var i = 0; i < doc.nodes.length; i++) used[doc.nodes[i].id] = true
+  while (used["n" + n]) n++
+  return "n" + n
+}
+
+function emptyDoc(name) {
+  return { v: VERSION, name: name || DEFAULT_NAME, nodes: [] }
+}
+
+// What a brand new design starts as: a wallpaper, the time, the date and a
+// place to type. Enough that pressing Save right away gives a lock screen
+// that works.
+function starterDoc(name) {
+  var doc = emptyDoc(name)
+  function add(kindId, anchor, dx, dy, spec) {
+    var n = newNode(kindId, nextId(doc))
+    n.anchor = anchor
+    n.dx = dx
+    n.dy = dy
+    if (spec) for (var key in spec) n.spec[key] = spec[key]
+    doc.nodes.push(n)
+    return n
+  }
+  add("wallpaper", "center", 0, 0)
+  add("clock", "center", 0, -170)
+  add("date", "center", 0, -60)
+  add("password", "center", 0, 40)
+  add("status", "center", 0, 110)
+  return doc
+}
+
+function validate(doc) {
+  if (!doc || typeof doc !== "object") return null
+  if (!(doc.nodes instanceof Array)) return null
+  var out = { v: VERSION, name: String(doc.name || DEFAULT_NAME), nodes: [] }
+  for (var i = 0; i < doc.nodes.length; i++) {
+    var n = doc.nodes[i]
+    if (!n || !KINDS[n.kind]) continue
+    out.nodes.push({
+      id: String(n.id || ("n" + (i + 1))),
+      kind: String(n.kind),
+      anchor: ANCHORS.indexOf(n.anchor) === -1 ? "center" : n.anchor,
+      dx: Math.round(Number(n.dx) || 0),
+      dy: Math.round(Number(n.dy) || 0),
+      w: Math.max(0, Math.round(Number(n.w) || 0)),
+      h: Math.max(0, Math.round(Number(n.h) || 0)),
+      spec: (n.spec && typeof n.spec === "object") ? clone(n.spec) : clone(KINDS[n.kind].spec || {})
+    })
+  }
+  return out
+}
+
+// The designer holds its nodes as LayoutNode objects so the canvas can bind
+// to them; on the way to a file they become plain records again. Reads
+// `nodeId` or `id`, so it takes either shape.
+function plainNode(n) {
+  return {
+    id: String(n.nodeId !== undefined && String(n.nodeId).length > 0 ? n.nodeId : n.id),
+    kind: String(n.kind),
+    anchor: String(n.anchor),
+    dx: Math.round(n.dx) || 0,
+    dy: Math.round(n.dy) || 0,
+    w: Math.round(n.w) || 0,
+    h: Math.round(n.h) || 0,
+    spec: JSON.parse(JSON.stringify(n.spec || {}))
+  }
+}
+
+function docOf(nodes, name) {
+  var out = { v: VERSION, name: String(name || DEFAULT_NAME), nodes: [] }
+  for (var i = 0; i < (nodes || []).length; i++) out.nodes.push(plainNode(nodes[i]))
+  return out
+}
+
+function idsOf(nodes) {
+  var out = []
+  for (var i = 0; i < (nodes || []).length; i++)
+    out.push(String(nodes[i].nodeId !== undefined && String(nodes[i].nodeId).length > 0 ? nodes[i].nodeId : nodes[i].id))
+  return out
+}
+
+// The first free nN, given the ids already taken.
+function nextIdFrom(ids) {
+  var n = 1
+  var used = {}
+  for (var i = 0; i < ids.length; i++) used[ids[i]] = true
+  while (used["n" + n]) n++
+  return "n" + n
+}
+
+function serialize(doc) { return JSON.stringify(doc) }
+
+// Pull the layout back out of a design file. Returns null when the file was
+// not made here.
+function parse(text) {
+  var lines = String(text || "").split("\n")
+  for (var i = 0; i < lines.length && i < 40; i++) {
+    var l = lines[i]
+    var at = l.indexOf(MARKER)
+    if (at === -1) continue
+    try {
+      return validate(JSON.parse(l.substring(at + MARKER.length)))
+    } catch (e) {
+      return null
+    }
+  }
+  return null
+}
+
+function isDesignerFile(text) { return parse(text) !== null }
+
+// ------------------------------------------------------------- code writing
+
+function anchorLines(node, indent) {
+  var out = []
+  var col = anchorCol(node.anchor)
+  var row = anchorRow(node.anchor)
+  if (col === 0) {
+    out.push(indent + "anchors.left: parent.left")
+    out.push(indent + "anchors.leftMargin: " + node.dx)
+  } else if (col === 2) {
+    out.push(indent + "anchors.right: parent.right")
+    out.push(indent + "anchors.rightMargin: " + (-node.dx))
+  } else {
+    out.push(indent + "anchors.horizontalCenter: parent.horizontalCenter")
+    out.push(indent + "anchors.horizontalCenterOffset: " + node.dx)
+  }
+  if (row === 0) {
+    out.push(indent + "anchors.top: parent.top")
+    out.push(indent + "anchors.topMargin: " + node.dy)
+  } else if (row === 2) {
+    out.push(indent + "anchors.bottom: parent.bottom")
+    out.push(indent + "anchors.bottomMargin: " + (-node.dy))
+  } else {
+    out.push(indent + "anchors.verticalCenter: parent.verticalCenter")
+    out.push(indent + "anchors.verticalCenterOffset: " + node.dy)
+  }
+  return out
+}
+
+// The generated file is a DesignBase with one DesignerItem per node. The
+// layout comment above it is what the designer reads back; the code is
+// rewritten from it on every save.
+function generate(doc, pluginId) {
+  var out = []
+  var nodes = doc.nodes || []
+  var inputNode = null
+  for (var i = 0; i < nodes.length; i++) if (isInput(nodes[i])) { inputNode = nodes[i]; break }
+
+  out.push("// " + doc.name + " — made with the lock screen designer.")
+  out.push("// Open it there again with E in the explorer (omarchy-shell lock explore).")
+  out.push("// Everything below the layout line is generated from it: edit the code by")
+  out.push("// hand and the next save from the designer replaces it.")
+  out.push("// " + MARKER + serialize(doc))
+  out.push("import QtQuick")
+  out.push("import QtQuick.Effects")
+  out.push("import qs.Commons")
+  out.push('import "../plugins/' + pluginId + '/designs"')
+  out.push("")
+  out.push("DesignBase {")
+  out.push("  id: lock")
+  out.push("  inputItem: " + (inputNode ? inputNode.id + ".inputItem" : "fallbackInput"))
+  out.push("")
+  out.push("  MouseArea {")
+  out.push("    anchors.fill: parent")
+  out.push("    hoverEnabled: true")
+  out.push("    onClicked: { lock.wakeRequested(); lock.forcePasswordFocus() }")
+  out.push("    onPositionChanged: lock.wakeRequested()")
+  out.push("  }")
+
+  if (!inputNode) {
+    out.push("")
+    out.push("  // No input component in the layout — this keeps the screen unlockable.")
+    out.push("  LockInput { id: fallbackInput; lock: lock; anchors.centerIn: parent; width: 1; height: 1; opacity: 0 }")
+  }
+
+  for (var j = 0; j < nodes.length; j++) {
+    var n = nodes[j]
+    var k = KINDS[n.kind]
+    out.push("")
+    out.push("  // " + k.name)
+    out.push("  DesignerItem {")
+    out.push("    id: " + n.id)
+    out.push("    lock: lock")
+    out.push('    kind: "' + n.kind + '"')
+    if (k.fill) {
+      out.push("    fillParent: true")
+    } else {
+      var lines = anchorLines(n, "    ")
+      for (var a = 0; a < lines.length; a++) out.push(lines[a])
+      if (n.w > 0) out.push("    fixedWidth: " + n.w)
+      if (n.h > 0 && !k.square) out.push("    fixedHeight: " + n.h)
+    }
+    if (n.kind === "custom") {
+      var body = String((n.spec && n.spec.qml) || "").split("\n")
+      out.push("")
+      for (var b = 0; b < body.length; b++) out.push(body[b].length > 0 ? "    " + body[b] : "")
+    } else {
+      out.push("    spec: (" + JSON.stringify(n.spec || {}) + ")")
+    }
+    out.push("  }")
+  }
+
+  out.push("}")
+  return out.join("\n") + "\n"
+}
+
+// -------------------------------------------------------------- components
+
+// A saved component is a group of nodes with their offsets kept relative to
+// the group's own top-left corner, so it can be dropped anywhere:
+//   { v: 1, name: "Glass card", w: 420, h: 260,
+//     nodes: [ { ...node, rx: 0, ry: 0 }, ... ] }
+function makeComponent(name, nodes, rects) {
+  if (!nodes || nodes.length === 0) return null
+  nodes = nodes.map(plainNode)
+  var minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity
+  for (var i = 0; i < nodes.length; i++) {
+    var r = rects[i]
+    minX = Math.min(minX, r.x)
+    minY = Math.min(minY, r.y)
+    maxX = Math.max(maxX, r.x + r.w)
+    maxY = Math.max(maxY, r.y + r.h)
+  }
+  var out = { v: VERSION, name: String(name || "Component"), w: Math.round(maxX - minX), h: Math.round(maxY - minY), nodes: [] }
+  for (var j = 0; j < nodes.length; j++) {
+    var n = clone(nodes[j])
+    n.rx = Math.round(rects[j].x - minX)
+    n.ry = Math.round(rects[j].y - minY)
+    // The size it actually rendered at, needed to re-derive offsets for the
+    // pieces that size themselves from their content.
+    n.rw = Math.round(rects[j].w)
+    n.rh = Math.round(rects[j].h)
+    out.nodes.push(n)
+  }
+  return out
+}
+
+function componentSlug(name) {
+  var s = String(name || "component").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "")
+  return s.length > 0 ? s : "component"
+}
+
+// Lay a saved component out at a screen position, as plain nodes ready to be
+// added to a design. Every piece takes the anchor of the group's centre, so
+// the group travels together.
+function instantiate(takenIds, comp, x, y, screenW, screenH) {
+  var made = []
+  var ids = (takenIds || []).slice()
+  var anchor = anchorAt(x + (comp.w || 0) / 2, y + (comp.h || 0) / 2, screenW, screenH)
+  for (var i = 0; i < (comp.nodes || []).length; i++) {
+    var src = comp.nodes[i]
+    if (!KINDS[src.kind]) continue
+    var n = clone(src)
+    n.id = nextIdFrom(ids)
+    ids.push(n.id)
+    var nx = x + (Number(n.rx) || 0)
+    var ny = y + (Number(n.ry) || 0)
+    var w = n.w > 0 ? n.w : (Number(n.rw) || 0)
+    var h = n.h > 0 ? n.h : (Number(n.rh) || 0)
+    n.anchor = anchor
+    n.dx = Math.round(dxFor(anchor, nx, w, screenW))
+    n.dy = Math.round(dyFor(anchor, ny, h, screenH))
+    delete n.rx
+    delete n.ry
+    delete n.rw
+    delete n.rh
+    made.push(n)
+  }
+  return made
+}

--- a/Designer.qml
+++ b/Designer.qml
@@ -1,0 +1,1573 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+import qs.Commons
+import "designs"
+import "Designer.js" as D
+
+// The visual designer: a palette of pieces on the left, the lock screen at
+// its real size in the middle, and the settings for whatever is selected on
+// the right.
+//
+// The layout is a list of LayoutNode objects; the canvas renders it through
+// the same DesignerItem the generated file uses, so the canvas is the lock
+// screen, not a drawing of it. Saving writes the QML, with the layout itself
+// on one comment line for the next time it is opened.
+Item {
+  id: designer
+
+  property var service: null
+  property var design: null
+  property string pluginId: "io.github.sirjul1337.lock-explorer"
+  property color background: Color.menu.background
+  property color foreground: Color.menu.text
+  property color accent: Color.accent
+  property string fontFamily: Style.font.menuFamily
+  property real screenWidth: 1920
+  property real screenHeight: 1080
+
+  readonly property color muted: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.55)
+  readonly property color line: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.14)
+  readonly property color well: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.05)
+
+  readonly property string path: design && design.path
+    ? decodeURIComponent(String(design.path).replace(/^file:\/\//, "")) : ""
+
+  // The layout, as LayoutNode objects. `nodes` is reassigned (a fresh array)
+  // whenever pieces are added, removed or restacked; editing one needs no
+  // announcement, the canvas is bound to its properties.
+  property var nodes: []
+  property string docName: D.DEFAULT_NAME
+  property var selection: []
+  property bool dirty: false
+  property bool confirmDiscard: false
+  property string status: ""
+  property string loadError: ""
+  property var undoStack: []
+  property var redoStack: []
+  property string undoTag: ""
+  property var guides: []
+  // Set while the file dialog is up, so the picked path lands in the right
+  // place when the explorer comes back.
+  property string pendingFileKey: ""
+  property bool namingComponent: false
+  property string hoverHint: ""
+
+  readonly property var primary: selection.length === 0 ? null : nodeById(selection[selection.length - 1])
+  readonly property var primaryKind: primary ? D.kind(primary.kind) : null
+  readonly property var componentList: service ? service.components : []
+
+  signal closeRequested()
+  signal openCodeRequested(string path)
+  signal useRequested()
+  signal pickFileRequested()
+
+  Component {
+    id: nodeComponent
+    LayoutNode {}
+  }
+
+  function makeNode(plain) {
+    return nodeComponent.createObject(designer, {
+      nodeId: plain.id, kind: plain.kind, anchor: plain.anchor,
+      dx: plain.dx, dy: plain.dy, w: plain.w, h: plain.h, spec: plain.spec
+    })
+  }
+
+  function currentDoc() { return D.docOf(designer.nodes, designer.docName) }
+
+  function newNodeId() { return D.nextIdFrom(D.idsOf(designer.nodes)) }
+
+  // -------------------------------------------------------------- the file
+
+  FileView {
+    id: file
+    path: designer.path
+    watchChanges: false
+    atomicWrites: true
+    printErrors: false
+    onSaved: {
+      designer.status = "Saved " + Qt.formatTime(new Date(), "HH:mm:ss")
+      designer.dirty = false
+      if (designer.service && typeof designer.service.reloadDesigns === "function")
+        designer.service.reloadDesigns()
+    }
+    onSaveFailed: function(error) { designer.status = "Save failed: " + error }
+    onLoadFailed: designer.loadError = "Cannot read " + designer.path
+    onLoaded: designer.adopt(file.text())
+  }
+
+  onPathChanged: if (path.length > 0) load()
+
+  // Take the keyboard as soon as the designer is actually on screen. Asking
+  // for it when the explorer switches views is too early — the card is not
+  // laid out yet, the focus attempt is dropped, and every shortcut here stays
+  // dead until the first click lands inside.
+  onVisibleChanged: if (visible) Qt.callLater(designer.focusCanvas)
+
+  function load() {
+    loadError = ""
+    status = ""
+    file.reload()
+  }
+
+  function adopt(text) {
+    var parsed = D.parse(text)
+    if (!parsed) {
+      loadError = "This design was not made in the designer. Open it with the code editor instead."
+      return
+    }
+    loadError = ""
+    applyDoc(parsed)
+    undoStack = []
+    redoStack = []
+    dirty = false
+    confirmDiscard = false
+  }
+
+  function applyDoc(plain) {
+    var gone = designer.nodes
+    var made = []
+    for (var i = 0; i < plain.nodes.length; i++) made.push(makeNode(plain.nodes[i]))
+    designer.docName = plain.name
+    designer.nodes = made
+    designer.selection = []
+    // Only once the canvas has let go of them.
+    syncNodes()
+    for (var j = 0; j < gone.length; j++) gone[j].destroy()
+  }
+
+  function save() {
+    if (path.length === 0) return
+    file.setText(D.generate(currentDoc(), pluginId))
+    status = "Saving…"
+    confirmDiscard = false
+  }
+
+  function requestClose() {
+    if (dirty && !confirmDiscard) {
+      confirmDiscard = true
+      status = "Unsaved changes. Ctrl+S to save, Esc again to discard."
+      return
+    }
+    closeRequested()
+  }
+
+  // ------------------------------------------------------------- the model
+
+  function syncNodes() { stage.nodes = designer.nodes.slice() }
+
+  function touch() { dirty = true }
+
+  function indexOfId(id) {
+    for (var i = 0; i < designer.nodes.length; i++) if (designer.nodes[i].nodeId === id) return i
+    return -1
+  }
+
+  function nodeById(id) {
+    var i = indexOfId(id)
+    return i === -1 ? null : designer.nodes[i]
+  }
+
+  // Undo is a stack of whole layouts — small enough to copy, and it cannot
+  // drift out of step with the document the way a list of edits can.
+  function pushUndo(tag) {
+    if (tag !== undefined && tag !== null && tag === undoTag) return
+    undoTag = tag === undefined ? "" : tag
+    undoStack = undoStack.concat([JSON.stringify(currentDoc())])
+    if (undoStack.length > 60) undoStack = undoStack.slice(undoStack.length - 60)
+    redoStack = []
+  }
+
+  function undo() {
+    if (undoStack.length === 0) return
+    redoStack = redoStack.concat([JSON.stringify(currentDoc())])
+    applyDoc(JSON.parse(undoStack[undoStack.length - 1]))
+    undoStack = undoStack.slice(0, undoStack.length - 1)
+    undoTag = ""
+    dirty = true
+  }
+
+  function redo() {
+    if (redoStack.length === 0) return
+    undoStack = undoStack.concat([JSON.stringify(currentDoc())])
+    applyDoc(JSON.parse(redoStack[redoStack.length - 1]))
+    redoStack = redoStack.slice(0, redoStack.length - 1)
+    undoTag = ""
+    dirty = true
+  }
+
+  function select(ids) {
+    selection = ids
+    undoTag = ""
+  }
+
+  function nodePressed(id, additive) {
+    if (additive) {
+      var next = selection.slice()
+      var at = next.indexOf(id)
+      if (at === -1) next.push(id)
+      else next.splice(at, 1)
+      select(next)
+    } else if (selection.indexOf(id) === -1) {
+      select([id])
+    }
+  }
+
+  // Put a node's top-left corner at x/y by adjusting its offset from
+  // whatever it is anchored to.
+  function placeAt(index, x, y) {
+    var n = designer.nodes[index]
+    var r = stage.rectOf(index)
+    n.dx = Math.round(D.dxFor(n.anchor, x, r.w, screenWidth))
+    n.dy = Math.round(D.dyFor(n.anchor, y, r.h, screenHeight))
+  }
+
+  // Edges and centers worth lining up with: the screen's own, and every
+  // other node's. Whatever the drag lands within 8px of wins, and the
+  // matching line is drawn.
+  function snapDrag(index, x, y, w, h) {
+    var threshold = 8
+    var xs = [{ v: screenWidth / 2, mid: true }, { v: 0 }, { v: screenWidth }]
+    var ys = [{ v: screenHeight / 2, mid: true }, { v: 0 }, { v: screenHeight }]
+    for (var i = 0; i < designer.nodes.length; i++) {
+      if (i === index || D.isFill(designer.nodes[i])) continue
+      var r = stage.rectOf(i)
+      xs.push({ v: r.x }, { v: r.x + r.w }, { v: r.x + r.w / 2, mid: true })
+      ys.push({ v: r.y }, { v: r.y + r.h }, { v: r.y + r.h / 2, mid: true })
+    }
+
+    var hits = []
+    function best(candidates, pos, size) {
+      var bestDelta = null
+      var bestLine = null
+      var edges = [{ at: pos, mid: false }, { at: pos + size, mid: false }, { at: pos + size / 2, mid: true }]
+      for (var c = 0; c < candidates.length; c++) {
+        for (var e = 0; e < edges.length; e++) {
+          // Centers meet centers and edges meet edges; crossing the two makes
+          // everything cling to everything and nothing line up.
+          if (!!candidates[c].mid !== edges[e].mid) continue
+          var delta = candidates[c].v - edges[e].at
+          if (Math.abs(delta) > threshold) continue
+          if (bestDelta === null || Math.abs(delta) < Math.abs(bestDelta)) {
+            bestDelta = delta
+            bestLine = candidates[c].v
+          }
+        }
+      }
+      if (bestDelta === null) return { pos: pos, line: null }
+      return { pos: pos + bestDelta, line: bestLine }
+    }
+
+    var hx = best(xs, x, w)
+    var hy = best(ys, y, h)
+    if (hx.line !== null) hits.push({ vertical: true, at: hx.line })
+    if (hy.line !== null) hits.push({ vertical: false, at: hy.line })
+    guides = hits
+    return { x: hx.pos, y: hy.pos }
+  }
+
+  function nodeDragged(id, x, y) {
+    var index = indexOfId(id)
+    if (index === -1) return
+    var r = stage.rectOf(index)
+    var snapped = snapDrag(index, x, y, r.w, r.h)
+    var ddx = Math.round(snapped.x - r.x)
+    var ddy = Math.round(snapped.y - r.y)
+    if (ddx === 0 && ddy === 0) return
+    pushUndo("drag")
+    // Dragging one of several selected pieces moves the whole selection.
+    var ids = (selection.indexOf(id) !== -1 && selection.length > 1) ? selection : [id]
+    var rects = []
+    var indexes = []
+    for (var i = 0; i < ids.length; i++) {
+      var at = indexOfId(ids[i])
+      if (at === -1 || D.isFill(designer.nodes[at])) continue
+      indexes.push(at)
+      rects.push(stage.rectOf(at))
+    }
+    for (var j = 0; j < indexes.length; j++)
+      placeAt(indexes[j], rects[j].x + ddx, rects[j].y + ddy)
+    touch()
+  }
+
+  function nodeResized(id, w, h) {
+    var index = indexOfId(id)
+    if (index === -1) return
+    var n = designer.nodes[index]
+    var r = stage.rectOf(index)
+    pushUndo("resize")
+    n.w = w
+    n.h = h
+    // Growing from the corner leaves the top-left where it was, whichever
+    // edge the piece is anchored to.
+    n.dx = Math.round(D.dxFor(n.anchor, r.x, w, screenWidth))
+    n.dy = Math.round(D.dyFor(n.anchor, r.y, h, screenHeight))
+    touch()
+  }
+
+  function dragEnded() {
+    guides = []
+    undoTag = ""
+  }
+
+  // --------------------------------------------------------------- editing
+
+  function addNode(kindId, x, y) {
+    var plain = D.newNode(kindId, newNodeId())
+    if (!plain) return
+    pushUndo()
+    var fill = D.isFill(plain)
+    if (!fill) plain.anchor = D.anchorAt(x, y, screenWidth, screenHeight)
+    var n = makeNode(plain)
+    // Backgrounds go underneath everything, which is the only place they
+    // make sense.
+    designer.nodes = fill ? [n].concat(designer.nodes) : designer.nodes.concat([n])
+    syncNodes()
+    select([n.nodeId])
+    dirty = true
+    if (!fill) {
+      // The size is only known once it has drawn, so centre it on the drop
+      // after the fact.
+      var id = n.nodeId
+      Qt.callLater(function() {
+        var at = designer.indexOfId(id)
+        if (at === -1) return
+        var r = stage.rectOf(at)
+        designer.placeAt(at, x - r.w / 2, y - r.h / 2)
+        designer.touch()
+      })
+    }
+    status = D.kindName(kindId) + " added"
+  }
+
+  function addComponent(comp, x, y) {
+    if (!comp) return
+    pushUndo()
+    var plain = D.instantiate(D.idsOf(designer.nodes), comp,
+                              Math.round(x - (comp.w || 0) / 2), Math.round(y - (comp.h || 0) / 2),
+                              screenWidth, screenHeight)
+    var made = []
+    var ids = []
+    for (var i = 0; i < plain.length; i++) {
+      made.push(makeNode(plain[i]))
+      ids.push(plain[i].id)
+    }
+    designer.nodes = designer.nodes.concat(made)
+    syncNodes()
+    select(ids)
+    dirty = true
+    status = comp.name + " added"
+  }
+
+  function removeSelected() {
+    if (selection.length === 0) return
+    pushUndo()
+    var keep = []
+    var gone = []
+    for (var i = 0; i < designer.nodes.length; i++) {
+      if (selection.indexOf(designer.nodes[i].nodeId) === -1) keep.push(designer.nodes[i])
+      else gone.push(designer.nodes[i])
+    }
+    designer.nodes = keep
+    syncNodes()
+    select([])
+    for (var j = 0; j < gone.length; j++) gone[j].destroy()
+    dirty = true
+  }
+
+  function duplicateSelected() {
+    if (selection.length === 0) return
+    pushUndo()
+    var made = []
+    var ids = []
+    var taken = D.idsOf(designer.nodes)
+    for (var i = 0; i < selection.length; i++) {
+      var src = nodeById(selection[i])
+      if (!src) continue
+      var copy = D.plainNode(src)
+      copy.id = D.nextIdFrom(taken)
+      taken.push(copy.id)
+      copy.dx += 24
+      copy.dy += 24
+      made.push(makeNode(copy))
+      ids.push(copy.id)
+    }
+    designer.nodes = designer.nodes.concat(made)
+    syncNodes()
+    select(ids)
+    dirty = true
+  }
+
+  function nudge(ddx, ddy) {
+    if (selection.length === 0) return
+    pushUndo("nudge")
+    for (var i = 0; i < selection.length; i++) {
+      var n = nodeById(selection[i])
+      if (!n || D.isFill(n)) continue
+      n.dx += ddx
+      n.dy += ddy
+    }
+    touch()
+  }
+
+  // Reorder: 1 up one place, -1 down one, 2 to the front, -2 to the back.
+  function restack(how) {
+    if (selection.length === 0) return
+    pushUndo()
+    var picked = []
+    var rest = []
+    for (var i = 0; i < designer.nodes.length; i++)
+      (selection.indexOf(designer.nodes[i].nodeId) === -1 ? rest : picked).push(designer.nodes[i])
+    if (how === 2) designer.nodes = rest.concat(picked)
+    else if (how === -2) designer.nodes = picked.concat(rest)
+    else {
+      var order = designer.nodes.slice()
+      var indexes = []
+      for (var j = 0; j < order.length; j++)
+        if (selection.indexOf(order[j].nodeId) !== -1) indexes.push(j)
+      if (how > 0) indexes.reverse()
+      for (var k = 0; k < indexes.length; k++) {
+        var from = indexes[k]
+        var to = from + (how > 0 ? 1 : -1)
+        if (to < 0 || to >= order.length) continue
+        if (selection.indexOf(order[to].nodeId) !== -1) continue
+        var tmp = order[to]
+        order[to] = order[from]
+        order[from] = tmp
+      }
+      designer.nodes = order
+    }
+    syncNodes()
+    dirty = true
+  }
+
+  function setProp(key, value) {
+    if (selection.length === 0) return
+    pushUndo("prop:" + key)
+    for (var i = 0; i < selection.length; i++) {
+      var n = nodeById(selection[i])
+      if (!n) continue
+      var kind = D.kind(n.kind)
+      if (!kind) continue
+      var known = false
+      for (var f = 0; f < kind.fields.length; f++) if (kind.fields[f].key === key) known = true
+      if (!known) continue
+      // A fresh object, so the item's bindings see a new value.
+      var spec = {}
+      for (var k in n.spec) spec[k] = n.spec[k]
+      spec[key] = value
+      n.spec = spec
+    }
+    touch()
+  }
+
+  function setGeometry(key, value) {
+    if (selection.length === 0) return
+    pushUndo("geom:" + key)
+    for (var i = 0; i < selection.length; i++) {
+      var n = nodeById(selection[i])
+      if (!n) continue
+      n[key] = Math.round(value)
+    }
+    touch()
+  }
+
+  function setAnchor(anchor) {
+    if (selection.length === 0) return
+    pushUndo()
+    for (var i = 0; i < selection.length; i++) {
+      var index = indexOfId(selection[i])
+      if (index === -1) continue
+      var r = stage.rectOf(index)
+      D.reanchor(designer.nodes[index], anchor, r.w, r.h, screenWidth, screenHeight)
+    }
+    touch()
+  }
+
+  // ------------------------------------------------------------ components
+
+  function saveSelectionAsComponent(name) {
+    if (selection.length === 0 || !service) return
+    var nodes = []
+    var rects = []
+    for (var i = 0; i < designer.nodes.length; i++) {
+      if (selection.indexOf(designer.nodes[i].nodeId) === -1) continue
+      // A full-screen background is not a piece you can place, so it never
+      // travels inside a component.
+      if (D.isFill(designer.nodes[i])) continue
+      nodes.push(designer.nodes[i])
+      rects.push(stage.rectOf(i))
+    }
+    if (nodes.length === 0) {
+      status = "Backgrounds cannot be saved as a component"
+      return
+    }
+    var comp = D.makeComponent(name, nodes, rects)
+    service.saveComponent(D.componentSlug(name), JSON.stringify(comp))
+    namingComponent = false
+    status = "Saved “" + comp.name + "” to your components"
+  }
+
+  function deleteComponent(slug) {
+    if (service) service.deleteComponent(slug)
+  }
+
+  // ---------------------------------------------------------------- canvas
+
+  readonly property real canvasScale: Math.min(canvasFrame.width / screenWidth, canvasFrame.height / screenHeight)
+
+  function canvasToStage(px, py) {
+    return { x: (px - stageWrap.x) / canvasScale, y: (py - stageWrap.y) / canvasScale }
+  }
+
+  function focusCanvas() { keys.forceActiveFocus() }
+
+  // Where a piece ended up on screen, in the screen's own coordinates.
+  function stageRect(index) { return stage.rectOf(index) }
+
+  function fileFieldPicked(picked) {
+    if (pendingFileKey.length === 0 || String(picked || "").length === 0) return
+    setProp(pendingFileKey, String(picked))
+    pendingFileKey = ""
+  }
+
+  // ------------------------------------------------------------------- keys
+
+  Item {
+    id: keys
+    anchors.fill: parent
+    focus: true
+    Keys.onPressed: function(event) {
+      var stepSize = (event.modifiers & Qt.ShiftModifier) ? 10 : 1
+      if (event.key === Qt.Key_Escape) {
+        designer.requestClose(); event.accepted = true
+      } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_S) {
+        designer.save(); event.accepted = true
+      } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_Z) {
+        if (event.modifiers & Qt.ShiftModifier) designer.redo(); else designer.undo()
+        event.accepted = true
+      } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_Y) {
+        designer.redo(); event.accepted = true
+      } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_D) {
+        designer.duplicateSelected(); event.accepted = true
+      } else if ((event.modifiers & Qt.ControlModifier) && event.key === Qt.Key_A) {
+        var all = []
+        for (var i = 0; i < designer.nodes.length; i++) all.push(designer.nodes[i].nodeId)
+        designer.select(all); event.accepted = true
+      } else if (event.key === Qt.Key_Delete || event.key === Qt.Key_Backspace) {
+        designer.removeSelected(); event.accepted = true
+      } else if (event.key === Qt.Key_Left) {
+        designer.nudge(-stepSize, 0); event.accepted = true
+      } else if (event.key === Qt.Key_Right) {
+        designer.nudge(stepSize, 0); event.accepted = true
+      } else if (event.key === Qt.Key_Up) {
+        designer.nudge(0, -stepSize); event.accepted = true
+      } else if (event.key === Qt.Key_Down) {
+        designer.nudge(0, stepSize); event.accepted = true
+      } else if (event.key === Qt.Key_BracketRight) {
+        designer.restack(event.modifiers & Qt.ShiftModifier ? 2 : 1); event.accepted = true
+      } else if (event.key === Qt.Key_BracketLeft) {
+        designer.restack(event.modifiers & Qt.ShiftModifier ? -2 : -1); event.accepted = true
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- layout
+
+  readonly property int panelW: Style.space(210)
+  readonly property int inspectorW: Style.space(270)
+
+  Item {
+    id: toolbar
+    anchors.top: parent.top
+    anchors.left: parent.left
+    anchors.right: parent.right
+    height: Style.space(40)
+
+    Column {
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: 1
+      Text {
+        text: designer.docName
+        textFormat: Text.PlainText
+        color: designer.foreground
+        font.family: designer.fontFamily
+        font.pixelSize: Style.font.title
+        font.weight: Font.DemiBold
+      }
+      Text {
+        text: designer.nodes.length + (designer.nodes.length === 1 ? " piece" : " pieces")
+          + (designer.dirty ? "  ·  unsaved" : "")
+        textFormat: Text.PlainText
+        color: designer.dirty ? designer.accent : designer.muted
+        font.family: designer.fontFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
+
+    Row {
+      anchors.right: parent.right
+      anchors.verticalCenter: parent.verticalCenter
+      spacing: Style.space(6)
+
+      DesignerButton {
+        label: "Undo"
+        active: designer.undoStack.length > 0
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.undo()
+      }
+      DesignerButton {
+        label: "Redo"
+        active: designer.redoStack.length > 0
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.redo()
+      }
+      DesignerButton {
+        label: "Edit code"
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.openCodeRequested(designer.path)
+      }
+      DesignerButton {
+        label: "Use this design"
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.useRequested()
+      }
+      DesignerButton {
+        label: "Save  Ctrl+S"
+        primary: designer.dirty
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.save()
+      }
+      DesignerButton {
+        label: "Back  Esc"
+        foreground: designer.foreground
+        accent: designer.accent
+        onClicked: designer.requestClose()
+      }
+    }
+  }
+
+  Text {
+    id: errorBanner
+    anchors.top: toolbar.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    visible: designer.loadError.length > 0
+    height: visible ? implicitHeight + Style.space(8) : 0
+    verticalAlignment: Text.AlignVCenter
+    text: designer.loadError
+    textFormat: Text.PlainText
+    color: Color.lock.textError
+    font.family: designer.fontFamily
+    font.pixelSize: Style.font.bodySmall
+    wrapMode: Text.Wrap
+  }
+
+  // ------------------------------------------------------------- palette
+
+  Rectangle {
+    id: palette
+    anchors.top: errorBanner.bottom
+    anchors.topMargin: Style.space(8)
+    anchors.bottom: footer.top
+    anchors.bottomMargin: Style.space(8)
+    anchors.left: parent.left
+    width: designer.panelW
+    radius: 6
+    color: designer.well
+    border.width: 1
+    border.color: designer.line
+    clip: true
+
+    Flickable {
+      anchors.fill: parent
+      anchors.margins: Style.space(10)
+      contentWidth: width
+      contentHeight: paletteColumn.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+
+      Column {
+        id: paletteColumn
+        width: parent.width
+        spacing: Style.space(6)
+
+        Text {
+          text: "YOUR COMPONENTS"
+          color: designer.muted
+          font.family: designer.fontFamily
+          font.pixelSize: Style.font.caption
+          font.letterSpacing: 1
+        }
+
+        Text {
+          width: parent.width
+          visible: designer.componentList.length === 0
+          text: "Select a piece (or several with Ctrl) and press “Save as component” to keep it here for every design."
+          textFormat: Text.PlainText
+          color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b, 0.35)
+          font.family: designer.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.Wrap
+        }
+
+        Repeater {
+          model: designer.componentList
+
+          Rectangle {
+            id: componentEntry
+            required property var modelData
+            width: paletteColumn.width
+            height: Style.space(54)
+            radius: 5
+            color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b,
+                           componentArea.containsMouse ? 0.14 : 0.06)
+            border.width: 1
+            border.color: designer.line
+            Behavior on color { ColorAnimation { duration: 100 } }
+
+            DesignerThumb {
+              anchors.left: parent.left
+              anchors.leftMargin: Style.space(6)
+              anchors.verticalCenter: parent.verticalCenter
+              width: Style.space(56)
+              height: Style.space(40)
+              lock: stage
+              comp: componentEntry.modelData.comp
+            }
+
+            Text {
+              anchors.left: parent.left
+              anchors.leftMargin: Style.space(68)
+              anchors.right: parent.right
+              anchors.rightMargin: Style.space(22)
+              anchors.verticalCenter: parent.verticalCenter
+              text: componentEntry.modelData.comp ? componentEntry.modelData.comp.name : componentEntry.modelData.slug
+              textFormat: Text.PlainText
+              color: designer.foreground
+              font.family: designer.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              elide: Text.ElideRight
+            }
+
+            Text {
+              anchors.right: parent.right
+              anchors.rightMargin: Style.space(7)
+              anchors.top: parent.top
+              anchors.topMargin: Style.space(5)
+              visible: componentArea.containsMouse || removeArea.containsMouse
+              text: "✕"
+              color: removeArea.containsMouse ? Color.lock.textError : designer.muted
+              font.family: designer.fontFamily
+              font.pixelSize: Style.font.caption
+              MouseArea {
+                id: removeArea
+                anchors.fill: parent
+                anchors.margins: -Style.space(5)
+                hoverEnabled: true
+                onClicked: designer.deleteComponent(componentEntry.modelData.slug)
+              }
+            }
+
+            Item {
+              id: componentGhost
+              parent: dragLayer
+              visible: componentArea.dragging
+              width: Style.space(120)
+              height: Style.space(30)
+              Drag.active: componentArea.dragging
+              Drag.hotSpot.x: width / 2
+              Drag.hotSpot.y: height / 2
+              Drag.keys: ["lock-designer-drop"]
+              property string payloadKind: ""
+              property var payloadComponent: componentEntry.modelData.comp
+
+              Rectangle {
+                anchors.fill: parent
+                radius: 5
+                color: Qt.rgba(designer.accent.r, designer.accent.g, designer.accent.b, 0.85)
+                Text {
+                  anchors.centerIn: parent
+                  text: componentEntry.modelData.comp ? componentEntry.modelData.comp.name : ""
+                  textFormat: Text.PlainText
+                  color: Color.background
+                  font.family: designer.fontFamily
+                  font.pixelSize: Style.font.caption
+                  font.weight: Font.DemiBold
+                }
+              }
+            }
+
+            MouseArea {
+              id: componentArea
+              anchors.fill: parent
+              anchors.rightMargin: Style.space(20)
+              hoverEnabled: true
+              // Same as the built-in pieces: the ghost is carried by hand.
+              property bool dragging: false
+              property real pressX: 0
+              property real pressY: 0
+
+              function carry(mouse) {
+                var p = mapToItem(dragLayer, mouse.x, mouse.y)
+                componentGhost.x = p.x - componentGhost.width / 2
+                componentGhost.y = p.y - componentGhost.height / 2
+              }
+
+              onPressed: function(mouse) {
+                pressX = mouse.x
+                pressY = mouse.y
+                dragging = false
+                carry(mouse)
+              }
+              onPositionChanged: function(mouse) {
+                if (!pressed) return
+                if (!dragging && Math.abs(mouse.x - pressX) < 6 && Math.abs(mouse.y - pressY) < 6) return
+                dragging = true
+                carry(mouse)
+              }
+              onReleased: {
+                if (dragging) {
+                  componentGhost.Drag.drop()
+                  dragging = false
+                } else {
+                  designer.addComponent(componentEntry.modelData.comp, designer.screenWidth / 2, designer.screenHeight / 2)
+                }
+              }
+              onCanceled: dragging = false
+            }
+          }
+        }
+
+        Repeater {
+          model: D.GROUPS
+
+          Column {
+            id: group
+            required property string modelData
+            readonly property var entries: D.paletteFor(modelData)
+            width: paletteColumn.width
+            spacing: Style.space(4)
+            topPadding: Style.space(6)
+
+            Text {
+              text: group.modelData.toUpperCase()
+              color: designer.muted
+              font.family: designer.fontFamily
+              font.pixelSize: Style.font.caption
+              font.letterSpacing: 1
+            }
+
+            Repeater {
+              model: group.entries
+
+              Rectangle {
+                id: entry
+                required property var modelData
+                width: group.width
+                height: Style.space(32)
+                radius: 5
+                color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b,
+                               entryArea.containsMouse ? 0.14 : 0.06)
+                border.width: 1
+                border.color: designer.line
+                Behavior on color { ColorAnimation { duration: 100 } }
+
+                Text {
+                  anchors.left: parent.left
+                  anchors.leftMargin: Style.space(9)
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: entry.modelData.kind.glyph
+                  color: designer.accent
+                  font.family: designer.fontFamily
+                  font.pixelSize: Style.font.title
+                }
+
+                Text {
+                  anchors.left: parent.left
+                  anchors.leftMargin: Style.space(32)
+                  anchors.right: parent.right
+                  anchors.rightMargin: Style.space(6)
+                  anchors.verticalCenter: parent.verticalCenter
+                  text: entry.modelData.kind.name
+                  textFormat: Text.PlainText
+                  color: designer.foreground
+                  font.family: designer.fontFamily
+                  font.pixelSize: Style.font.bodySmall
+                  elide: Text.ElideRight
+                }
+
+                Item {
+                  id: entryGhost
+                  parent: dragLayer
+                  visible: entryArea.dragging
+                  width: Style.space(120)
+                  height: Style.space(30)
+                  Drag.active: entryArea.dragging
+                  Drag.hotSpot.x: width / 2
+                  Drag.hotSpot.y: height / 2
+                  Drag.keys: ["lock-designer-drop"]
+                  property string payloadKind: entry.modelData.id
+                  property var payloadComponent: null
+
+                  Rectangle {
+                    anchors.fill: parent
+                    radius: 5
+                    color: Qt.rgba(designer.accent.r, designer.accent.g, designer.accent.b, 0.85)
+                    Text {
+                      anchors.centerIn: parent
+                      text: entry.modelData.kind.name
+                      textFormat: Text.PlainText
+                      color: Color.background
+                      font.family: designer.fontFamily
+                      font.pixelSize: Style.font.caption
+                      font.weight: Font.DemiBold
+                    }
+                  }
+                }
+
+                MouseArea {
+                  id: entryArea
+                  anchors.fill: parent
+                  hoverEnabled: true
+                  // The ghost is carried by hand rather than with drag.target:
+                  // it lives in the drag layer, outside this Flickable, and
+                  // MouseArea's own dragging maps the delta between the two
+                  // coordinate systems wrongly — the ghost ends up hundreds of
+                  // pixels away and drops onto nothing.
+                  property bool dragging: false
+                  property real pressX: 0
+                  property real pressY: 0
+
+                  function carry(mouse) {
+                    var p = mapToItem(dragLayer, mouse.x, mouse.y)
+                    entryGhost.x = p.x - entryGhost.width / 2
+                    entryGhost.y = p.y - entryGhost.height / 2
+                  }
+
+                  onPressed: function(mouse) {
+                    pressX = mouse.x
+                    pressY = mouse.y
+                    dragging = false
+                    carry(mouse)
+                  }
+                  onPositionChanged: function(mouse) {
+                    if (!pressed) return
+                    if (!dragging && Math.abs(mouse.x - pressX) < 6 && Math.abs(mouse.y - pressY) < 6) return
+                    dragging = true
+                    carry(mouse)
+                  }
+                  onReleased: {
+                    if (dragging) {
+                      entryGhost.Drag.drop()
+                      dragging = false
+                    } else {
+                      designer.addNode(entry.modelData.id, designer.screenWidth / 2, designer.screenHeight / 2)
+                    }
+                  }
+                  onCanceled: dragging = false
+                  // What it is, said in the footer where there is room for it.
+                  onEntered: designer.hoverHint = entry.modelData.kind.hint
+                  onExited: if (designer.hoverHint === entry.modelData.kind.hint) designer.hoverHint = ""
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- canvas
+
+  Item {
+    id: canvasFrame
+    anchors.top: errorBanner.bottom
+    anchors.topMargin: Style.space(8)
+    anchors.bottom: footer.top
+    anchors.bottomMargin: Style.space(8)
+    anchors.left: palette.right
+    anchors.leftMargin: Style.space(10)
+    anchors.right: inspector.left
+    anchors.rightMargin: Style.space(10)
+    clip: true
+
+    // Clicking past everything clears the selection. It sits under the stage,
+    // and reaches this far because the pieces that cover the screen — the
+    // backgrounds — deliberately take no clicks.
+    MouseArea {
+      anchors.fill: parent
+      onClicked: {
+        designer.select([])
+        designer.focusCanvas()
+      }
+    }
+
+    Rectangle {
+      x: stageWrap.x
+      y: stageWrap.y
+      width: designer.screenWidth * designer.canvasScale
+      height: designer.screenHeight * designer.canvasScale
+      color: "transparent"
+      border.width: 1
+      border.color: designer.line
+      z: 5
+    }
+
+    Item {
+      id: stageWrap
+      width: designer.screenWidth
+      height: designer.screenHeight
+      scale: designer.canvasScale
+      transformOrigin: Item.TopLeft
+      x: Math.round((canvasFrame.width - width * scale) / 2)
+      y: Math.round((canvasFrame.height - height * scale) / 2)
+
+      DesignerStage {
+        id: stage
+        anchors.fill: parent
+        editing: true
+        selection: designer.selection
+        viewScale: designer.canvasScale
+        backgroundPath: designer.service ? designer.service.backgroundPath : ""
+        backgroundVersion: designer.service ? designer.service.backgroundVersion : 0
+        avatarPath: designer.service ? designer.service.avatarPath : ""
+        avatarVersion: designer.service ? designer.service.avatarVersion : 0
+        videoPath: designer.service ? designer.service.videoPath : ""
+        fingerprintConfigured: designer.service ? designer.service.fingerprintConfigured : false
+        // Something in the box, so the input pieces are visible while arranging.
+        passwordText: "omarchy"
+        onNodePressed: function(id, additive) {
+          designer.nodePressed(id, additive)
+          designer.focusCanvas()
+        }
+        onNodeDragged: function(id, x, y) { designer.nodeDragged(id, x, y) }
+        onNodeResized: function(id, w, h) { designer.nodeResized(id, w, h) }
+        onNodeDragEnded: designer.dragEnded()
+      }
+
+      // Alignment guides, drawn in the screen's own coordinates so they land
+      // exactly on the edge they matched.
+      Repeater {
+        model: designer.guides
+        Rectangle {
+          required property var modelData
+          color: designer.accent
+          opacity: 0.8
+          width: modelData.vertical ? 1 / designer.canvasScale : stageWrap.width
+          height: modelData.vertical ? stageWrap.height : 1 / designer.canvasScale
+          x: modelData.vertical ? modelData.at : 0
+          y: modelData.vertical ? 0 : modelData.at
+        }
+      }
+    }
+
+    DropArea {
+      anchors.fill: parent
+      keys: ["lock-designer-drop"]
+      onDropped: function(drop) {
+        var at = designer.canvasToStage(drop.x, drop.y)
+        if (drop.source && drop.source.payloadComponent)
+          designer.addComponent(drop.source.payloadComponent, at.x, at.y)
+        else if (drop.source && String(drop.source.payloadKind).length > 0)
+          designer.addNode(String(drop.source.payloadKind), at.x, at.y)
+        designer.focusCanvas()
+      }
+    }
+  }
+
+  // ------------------------------------------------------------- inspector
+
+  Rectangle {
+    id: inspector
+    anchors.top: errorBanner.bottom
+    anchors.topMargin: Style.space(8)
+    anchors.bottom: footer.top
+    anchors.bottomMargin: Style.space(8)
+    anchors.right: parent.right
+    width: designer.inspectorW
+    radius: 6
+    color: designer.well
+    border.width: 1
+    border.color: designer.line
+    clip: true
+
+    Flickable {
+      anchors.fill: parent
+      anchors.margins: Style.space(10)
+      contentWidth: width
+      contentHeight: inspectorColumn.implicitHeight
+      clip: true
+      boundsBehavior: Flickable.StopAtBounds
+
+      Column {
+        id: inspectorColumn
+        width: parent.width
+        spacing: Style.space(10)
+
+        DesignerField {
+          width: parent.width
+          label: "DESIGN NAME"
+          type: "text"
+          value: designer.docName
+          foreground: designer.foreground
+          accent: designer.accent
+          onEdited: function(next) {
+            designer.pushUndo("name")
+            designer.docName = String(next)
+            designer.touch()
+          }
+          onEscaped: designer.focusCanvas()
+        }
+
+        Rectangle { width: parent.width; height: 1; color: designer.line }
+
+        Text {
+          width: parent.width
+          text: designer.selection.length === 0 ? "NOTHING SELECTED"
+            : (designer.selection.length > 1 ? designer.selection.length + " PIECES SELECTED"
+               : (designer.primaryKind ? designer.primaryKind.name.toUpperCase() : ""))
+          textFormat: Text.PlainText
+          color: designer.selection.length === 0 ? designer.muted : designer.accent
+          font.family: designer.fontFamily
+          font.pixelSize: Style.font.caption
+          font.letterSpacing: 1
+          font.weight: Font.DemiBold
+        }
+
+        Text {
+          width: parent.width
+          visible: designer.selection.length === 0
+          text: "Drag a piece onto the screen, or click one there to change it."
+          textFormat: Text.PlainText
+          color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b, 0.35)
+          font.family: designer.fontFamily
+          font.pixelSize: Style.font.caption
+          wrapMode: Text.Wrap
+        }
+
+        // ------------------------------------------------------- placement
+
+        Column {
+          width: parent.width
+          spacing: Style.space(6)
+          visible: designer.primary !== null && !D.isFill(designer.primary)
+
+          Text {
+            text: "STICKS TO"
+            color: designer.muted
+            font.family: designer.fontFamily
+            font.pixelSize: Style.font.caption
+            font.letterSpacing: 1
+          }
+
+          Row {
+            spacing: Style.space(10)
+
+            // A design has to survive a different screen, so a piece is not
+            // parked at an absolute spot: it holds on to a corner, an edge or
+            // the middle, and keeps its distance from that.
+            Grid {
+              columns: 3
+              spacing: Style.space(3)
+              Repeater {
+                model: D.ANCHORS
+                Rectangle {
+                  required property string modelData
+                  readonly property bool current: designer.primary && designer.primary.anchor === modelData
+                  width: Style.space(20)
+                  height: Style.space(20)
+                  radius: 3
+                  color: current ? designer.accent
+                    : Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b,
+                              anchorArea.containsMouse ? 0.18 : 0.08)
+                  border.width: 1
+                  border.color: current ? designer.accent : designer.line
+                  Rectangle {
+                    anchors.centerIn: parent
+                    width: Style.space(5)
+                    height: width
+                    radius: 1
+                    color: parent.current ? Color.background : designer.muted
+                  }
+                  MouseArea {
+                    id: anchorArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: designer.setAnchor(parent.modelData)
+                  }
+                }
+              }
+            }
+
+            Column {
+              spacing: Style.space(4)
+              width: inspectorColumn.width - Style.space(84)
+              DesignerField {
+                width: parent.width
+                label: "OFFSET X"
+                type: "number"
+                minimum: -10000
+                maximum: 10000
+                step: 1
+                value: designer.primary ? designer.primary.dx : 0
+                foreground: designer.foreground
+                accent: designer.accent
+                onEdited: function(next) { designer.setGeometry("dx", next) }
+                onEscaped: designer.focusCanvas()
+              }
+              DesignerField {
+                width: parent.width
+                label: "OFFSET Y"
+                type: "number"
+                minimum: -10000
+                maximum: 10000
+                step: 1
+                value: designer.primary ? designer.primary.dy : 0
+                foreground: designer.foreground
+                accent: designer.accent
+                onEdited: function(next) { designer.setGeometry("dy", next) }
+                onEscaped: designer.focusCanvas()
+              }
+            }
+          }
+
+          Row {
+            spacing: Style.space(8)
+            visible: designer.primary !== null && D.isSized(designer.primary)
+            DesignerField {
+              width: (inspectorColumn.width - Style.space(8)) / 2
+              label: "WIDTH"
+              type: "number"
+              minimum: 0
+              maximum: 10000
+              step: 1
+              value: designer.primary ? designer.primary.w : 0
+              foreground: designer.foreground
+              accent: designer.accent
+              onEdited: function(next) { designer.setGeometry("w", next) }
+              onEscaped: designer.focusCanvas()
+            }
+            DesignerField {
+              width: (inspectorColumn.width - Style.space(8)) / 2
+              label: "HEIGHT"
+              type: "number"
+              minimum: 0
+              maximum: 10000
+              step: 1
+              visible: designer.primary ? !D.isSquare(designer.primary) : false
+              value: designer.primary ? designer.primary.h : 0
+              foreground: designer.foreground
+              accent: designer.accent
+              onEdited: function(next) { designer.setGeometry("h", next) }
+              onEscaped: designer.focusCanvas()
+            }
+          }
+
+          Text {
+            width: parent.width
+            visible: designer.primary !== null && !D.isSized(designer.primary)
+            text: "Set a width to make it wrap; leave it at 0 and it hugs its text."
+            textFormat: Text.PlainText
+            color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b, 0.35)
+            font.family: designer.fontFamily
+            font.pixelSize: Style.font.caption
+            wrapMode: Text.Wrap
+          }
+
+          DesignerField {
+            width: parent.width
+            visible: designer.primary !== null && !D.isSized(designer.primary)
+            label: "WIDTH (0 = FIT TEXT)"
+            type: "number"
+            minimum: 0
+            maximum: 10000
+            step: 10
+            value: designer.primary ? designer.primary.w : 0
+            foreground: designer.foreground
+            accent: designer.accent
+            onEdited: function(next) { designer.setGeometry("w", next) }
+            onEscaped: designer.focusCanvas()
+          }
+        }
+
+        Rectangle {
+          width: parent.width
+          height: 1
+          color: designer.line
+          visible: designer.primary !== null
+        }
+
+        // ---------------------------------------------------------- fields
+
+        Repeater {
+          model: designer.primaryKind ? designer.primaryKind.fields : []
+
+          DesignerField {
+            required property var modelData
+            width: inspectorColumn.width
+            label: modelData.label.toUpperCase()
+            type: modelData.type
+            options: modelData.options ? modelData.options : []
+            minimum: modelData.min !== undefined ? modelData.min : 0
+            maximum: modelData.max !== undefined ? modelData.max : 1
+            step: modelData.step !== undefined ? modelData.step : 0.05
+            value: {
+              if (!designer.primary) return null
+              var v = designer.primary.spec[modelData.key]
+              return v === undefined ? null : v
+            }
+            foreground: designer.foreground
+            accent: designer.accent
+            onEdited: function(next) { designer.setProp(modelData.key, next) }
+            onEscaped: designer.focusCanvas()
+            onPickFileRequested: {
+              designer.pendingFileKey = modelData.key
+              designer.pickFileRequested()
+            }
+          }
+        }
+
+        // --------------------------------------------------------- actions
+
+        Rectangle {
+          width: parent.width
+          height: 1
+          color: designer.line
+          visible: designer.selection.length > 0
+        }
+
+        Flow {
+          width: parent.width
+          spacing: Style.space(5)
+          visible: designer.selection.length > 0
+
+          DesignerButton {
+            label: "Duplicate"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.duplicateSelected()
+          }
+          DesignerButton {
+            label: "Delete"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.removeSelected()
+          }
+          DesignerButton {
+            label: "Front"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.restack(2)
+          }
+          DesignerButton {
+            label: "Forward"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.restack(1)
+          }
+          DesignerButton {
+            label: "Back"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.restack(-1)
+          }
+          DesignerButton {
+            label: "Bottom"
+            foreground: designer.foreground
+            accent: designer.accent
+            onClicked: designer.restack(-2)
+          }
+        }
+
+        DesignerButton {
+          width: parent.width
+          visible: designer.selection.length > 0 && !designer.namingComponent
+          label: "Save as component"
+          foreground: designer.foreground
+          accent: designer.accent
+          onClicked: {
+            designer.namingComponent = true
+            Qt.callLater(function() { componentName.forceFieldFocus() })
+          }
+        }
+
+        Column {
+          id: componentName
+          width: parent.width
+          spacing: Style.space(5)
+          visible: designer.namingComponent
+
+          function forceFieldFocus() { nameEntry.forceActiveFocus() }
+
+          Text {
+            text: "NAME IT"
+            color: designer.muted
+            font.family: designer.fontFamily
+            font.pixelSize: Style.font.caption
+            font.letterSpacing: 1
+          }
+
+          Rectangle {
+            width: parent.width
+            height: Style.space(28)
+            radius: 4
+            color: Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b, 0.07)
+            border.width: 1
+            border.color: nameEntry.activeFocus ? designer.accent : designer.line
+            TextInput {
+              id: nameEntry
+              anchors.fill: parent
+              anchors.leftMargin: Style.space(8)
+              anchors.rightMargin: Style.space(8)
+              verticalAlignment: TextInput.AlignVCenter
+              color: designer.foreground
+              selectionColor: designer.accent
+              selectByMouse: true
+              font.family: designer.fontFamily
+              font.pixelSize: Style.font.bodySmall
+              onAccepted: if (text.trim().length > 0) designer.saveSelectionAsComponent(text.trim())
+              Keys.onPressed: function(event) {
+                if (event.key === Qt.Key_Escape) {
+                  designer.namingComponent = false
+                  designer.focusCanvas()
+                  event.accepted = true
+                }
+              }
+            }
+          }
+
+          Row {
+            spacing: Style.space(5)
+            DesignerButton {
+              label: "Save"
+              primary: true
+              foreground: designer.foreground
+              accent: designer.accent
+              onClicked: if (nameEntry.text.trim().length > 0) designer.saveSelectionAsComponent(nameEntry.text.trim())
+            }
+            DesignerButton {
+              label: "Cancel"
+              foreground: designer.foreground
+              accent: designer.accent
+              onClicked: { designer.namingComponent = false; designer.focusCanvas() }
+            }
+          }
+        }
+
+        // ---------------------------------------------------------- layers
+
+        Rectangle { width: parent.width; height: 1; color: designer.line }
+
+        Text {
+          text: "LAYERS  ·  TOP FIRST"
+          color: designer.muted
+          font.family: designer.fontFamily
+          font.pixelSize: Style.font.caption
+          font.letterSpacing: 1
+        }
+
+        Column {
+          width: parent.width
+          spacing: 1
+
+          Repeater {
+            // Top of the screen first, which is the end of the list.
+            model: designer.nodes.slice().reverse()
+
+            Rectangle {
+              id: layerRow
+              required property var modelData
+              readonly property bool current: designer.selection.indexOf(modelData.nodeId) !== -1
+              width: inspectorColumn.width
+              height: Style.space(24)
+              radius: 3
+              color: current ? Qt.rgba(designer.accent.r, designer.accent.g, designer.accent.b, 0.25)
+                : Qt.rgba(designer.foreground.r, designer.foreground.g, designer.foreground.b,
+                          layerArea.containsMouse ? 0.1 : 0.0)
+
+              Text {
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+                text: D.kind(layerRow.modelData.kind).glyph
+                color: layerRow.current ? designer.accent : designer.muted
+                font.family: designer.fontFamily
+                font.pixelSize: Style.font.bodySmall
+              }
+
+              Text {
+                anchors.left: parent.left
+                anchors.leftMargin: Style.space(26)
+                anchors.right: parent.right
+                anchors.rightMargin: Style.space(6)
+                anchors.verticalCenter: parent.verticalCenter
+                text: {
+                  var name = D.kindName(layerRow.modelData.kind)
+                  var body = String(layerRow.modelData.spec.text || "")
+                  return body.length > 0 ? name + " · " + body : name
+                }
+                textFormat: Text.PlainText
+                color: layerRow.current ? designer.foreground : designer.muted
+                font.family: designer.fontFamily
+                font.pixelSize: Style.font.caption
+                elide: Text.ElideRight
+              }
+
+              MouseArea {
+                id: layerArea
+                anchors.fill: parent
+                hoverEnabled: true
+                onClicked: function(mouse) {
+                  designer.nodePressed(layerRow.modelData.nodeId, (mouse.modifiers & Qt.ControlModifier) !== 0)
+                  if (!(mouse.modifiers & Qt.ControlModifier)) designer.select([layerRow.modelData.nodeId])
+                  designer.focusCanvas()
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- footer
+
+  Item {
+    id: footer
+    anchors.bottom: parent.bottom
+    anchors.left: parent.left
+    anchors.right: parent.right
+    height: Style.space(26)
+
+    Text {
+      anchors.left: parent.left
+      anchors.verticalCenter: parent.verticalCenter
+      width: parent.width - Style.space(20)
+      text: {
+        if (designer.hoverHint.length > 0) return designer.hoverHint
+        if (designer.status.length > 0) return designer.status
+        return "Drag pieces in   ·   arrows nudge (Shift: 10px)   ·   Ctrl+click multi-select   ·   Ctrl+D duplicate   ·   Del remove   ·   [ ] restack   ·   Ctrl+Z undo   ·   Ctrl+S save"
+      }
+      textFormat: Text.PlainText
+      color: designer.status.length > 0 && designer.hoverHint.length === 0 ? designer.foreground : designer.muted
+      font.family: designer.fontFamily
+      font.pixelSize: Style.font.caption
+      elide: Text.ElideRight
+    }
+  }
+
+  // Drag ghosts fly here, above the panels and the canvas alike.
+  Item {
+    id: dragLayer
+    anchors.fill: parent
+    z: 100
+  }
+}

--- a/DesignerButton.qml
+++ b/DesignerButton.qml
@@ -1,0 +1,44 @@
+import QtQuick
+import qs.Commons
+
+// A small flat button for the designer's toolbar and panels.
+Rectangle {
+  id: button
+
+  property string label: ""
+  property bool primary: false
+  property bool active: true
+  property color foreground: Color.menu.text
+  property color accent: Color.accent
+
+  signal clicked()
+
+  width: text.implicitWidth + Style.space(20)
+  height: Style.space(28)
+  radius: 5
+  opacity: active ? 1 : 0.4
+  color: primary ? accent
+    : Qt.rgba(foreground.r, foreground.g, foreground.b, area.containsMouse && active ? 0.16 : 0.07)
+  border.width: 1
+  border.color: primary ? accent : Qt.rgba(foreground.r, foreground.g, foreground.b, 0.15)
+  Behavior on color { ColorAnimation { duration: 100 } }
+
+  Text {
+    id: text
+    anchors.centerIn: parent
+    text: button.label
+    textFormat: Text.PlainText
+    color: button.primary ? Color.background : button.foreground
+    font.family: Style.font.menuFamily
+    font.pixelSize: Style.font.bodySmall
+    font.weight: button.primary ? Font.DemiBold : Font.Normal
+  }
+
+  MouseArea {
+    id: area
+    anchors.fill: parent
+    hoverEnabled: true
+    enabled: button.active
+    onClicked: button.clicked()
+  }
+}

--- a/DesignerField.qml
+++ b/DesignerField.qml
@@ -1,0 +1,487 @@
+import QtQuick
+import qs.Commons
+import "Designer.js" as D
+
+// One row in the designer's inspector. The kind's field list (Designer.js)
+// says which type to draw; every one of them reports back through edited().
+Item {
+  id: field
+
+  property string label: ""
+  property string type: "text"
+  property var value: null
+  property var options: []
+  property real minimum: 0
+  property real maximum: 1
+  property real step: 0.05
+  property color foreground: Color.menu.text
+  property color accent: Color.accent
+  readonly property color muted: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.55)
+  readonly property color well: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.07)
+  readonly property color line: Qt.rgba(foreground.r, foreground.g, foreground.b, 0.16)
+
+  signal edited(var next)
+  signal pickFileRequested()
+  // Esc in a field leaves it rather than closing the designer; the canvas
+  // takes the keyboard back.
+  signal escaped()
+
+  implicitHeight: column.implicitHeight
+  height: implicitHeight
+
+  function optionName(id) {
+    for (var i = 0; i < options.length; i++)
+      if (String(options[i].id) === String(id)) return options[i].name
+    return String(id)
+  }
+
+  Column {
+    id: column
+    width: field.width
+    spacing: Style.space(4)
+
+    Text {
+      text: field.label
+      textFormat: Text.PlainText
+      color: field.muted
+      font.family: Style.font.menuFamily
+      font.pixelSize: Style.font.caption
+      font.letterSpacing: 1
+    }
+
+    Loader {
+      width: parent.width
+      sourceComponent: {
+        switch (field.type) {
+        case "number": return numberC
+        case "slider": return sliderC
+        case "choice": return choiceC
+        case "color": return colorC
+        case "bool": return boolC
+        case "file": return fileC
+        case "code": return codeC
+        }
+        return textC
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------ text
+
+  Component {
+    id: textC
+    Rectangle {
+      implicitHeight: Style.space(28)
+      radius: 4
+      color: field.well
+      border.width: 1
+      border.color: entry.activeFocus ? field.accent : field.line
+
+      TextInput {
+        id: entry
+        anchors.fill: parent
+        anchors.leftMargin: Style.space(8)
+        anchors.rightMargin: Style.space(8)
+        verticalAlignment: TextInput.AlignVCenter
+        text: String(field.value === null || field.value === undefined ? "" : field.value)
+        color: field.foreground
+        selectionColor: field.accent
+        selectByMouse: true
+        clip: true
+        font.family: Style.font.menuFamily
+        font.pixelSize: Style.font.bodySmall
+        onTextEdited: field.edited(text)
+        Keys.onPressed: function(event) {
+          if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Escape) {
+            entry.focus = false
+            field.escaped()
+            event.accepted = true
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- number
+
+  Component {
+    id: numberC
+    Row {
+      spacing: Style.space(4)
+
+      Rectangle {
+        width: field.width - Style.space(56)
+        height: Style.space(28)
+        radius: 4
+        color: field.well
+        border.width: 1
+        border.color: numberEntry.activeFocus ? field.accent : field.line
+
+        TextInput {
+          id: numberEntry
+          anchors.fill: parent
+          anchors.leftMargin: Style.space(8)
+          anchors.rightMargin: Style.space(8)
+          verticalAlignment: TextInput.AlignVCenter
+          text: String(Math.round(Number(field.value) || 0))
+          color: field.foreground
+          selectionColor: field.accent
+          selectByMouse: true
+          inputMethodHints: Qt.ImhFormattedNumbersOnly
+          font.family: Style.font.menuFamily
+          font.pixelSize: Style.font.bodySmall
+          onTextEdited: {
+            var n = parseFloat(text)
+            if (isFinite(n)) field.edited(Math.max(field.minimum, Math.min(field.maximum, n)))
+          }
+          Keys.onPressed: function(event) {
+            if (event.key === Qt.Key_Return || event.key === Qt.Key_Enter || event.key === Qt.Key_Escape) {
+              numberEntry.focus = false
+              field.escaped()
+              event.accepted = true
+            } else if (event.key === Qt.Key_Up || event.key === Qt.Key_Down) {
+              var d = (event.key === Qt.Key_Up ? 1 : -1) * (event.modifiers & Qt.ShiftModifier ? 10 : 1) * field.step
+              field.edited(Math.max(field.minimum, Math.min(field.maximum, (Number(field.value) || 0) + d)))
+              event.accepted = true
+            }
+          }
+        }
+      }
+
+      Repeater {
+        model: ["−", "+"]
+        Rectangle {
+          required property string modelData
+          required property int index
+          width: Style.space(24)
+          height: Style.space(28)
+          radius: 4
+          color: stepArea.containsMouse ? Qt.rgba(field.foreground.r, field.foreground.g, field.foreground.b, 0.16) : field.well
+          border.width: 1
+          border.color: field.line
+          Text {
+            anchors.centerIn: parent
+            text: parent.modelData
+            color: field.foreground
+            font.family: Style.font.menuFamily
+            font.pixelSize: Style.font.bodySmall
+          }
+          MouseArea {
+            id: stepArea
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: {
+              var d = (parent.index === 1 ? 1 : -1) * field.step
+              field.edited(Math.max(field.minimum, Math.min(field.maximum, (Number(field.value) || 0) + d)))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- slider
+
+  Component {
+    id: sliderC
+    Item {
+      implicitHeight: Style.space(24)
+      readonly property real fraction: {
+        var span = field.maximum - field.minimum
+        if (span <= 0) return 0
+        return Math.max(0, Math.min(1, ((Number(field.value) || 0) - field.minimum) / span))
+      }
+
+      Rectangle {
+        id: track
+        anchors.verticalCenter: parent.verticalCenter
+        width: field.width - Style.space(44)
+        height: Style.space(6)
+        radius: height / 2
+        color: field.well
+        border.width: 1
+        border.color: field.line
+
+        Rectangle {
+          width: Math.round(parent.width * parent.parent.fraction)
+          height: parent.height
+          radius: parent.radius
+          color: field.accent
+        }
+
+        Rectangle {
+          x: Math.round(parent.width * parent.parent.fraction) - width / 2
+          anchors.verticalCenter: parent.verticalCenter
+          width: Style.space(12)
+          height: width
+          radius: width / 2
+          color: field.accent
+          border.width: 1
+          border.color: Qt.rgba(0, 0, 0, 0.4)
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          anchors.margins: -Style.space(8)
+          function apply(mx) {
+            var f = Math.max(0, Math.min(1, (mx - Style.space(8)) / track.width))
+            var raw = field.minimum + f * (field.maximum - field.minimum)
+            var snapped = field.step > 0 ? Math.round(raw / field.step) * field.step : raw
+            field.edited(Math.round(Math.max(field.minimum, Math.min(field.maximum, snapped)) * 1000) / 1000)
+          }
+          onPressed: function(mouse) { apply(mouse.x) }
+          onPositionChanged: function(mouse) { if (pressed) apply(mouse.x) }
+        }
+      }
+
+      Text {
+        anchors.right: parent.right
+        anchors.verticalCenter: parent.verticalCenter
+        text: (Math.round((Number(field.value) || 0) * 100) / 100).toFixed(2)
+        color: field.muted
+        font.family: Style.font.menuFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- choice
+
+  Component {
+    id: choiceC
+    Flow {
+      spacing: Style.space(4)
+      Repeater {
+        model: field.options
+        Rectangle {
+          required property var modelData
+          readonly property bool current: String(modelData.id) === String(field.value)
+          width: choiceLabel.implicitWidth + Style.space(14)
+          height: Style.space(24)
+          radius: 4
+          color: current ? field.accent
+            : Qt.rgba(field.foreground.r, field.foreground.g, field.foreground.b, choiceArea.containsMouse ? 0.16 : 0.07)
+          border.width: 1
+          border.color: current ? field.accent : field.line
+          Text {
+            id: choiceLabel
+            anchors.centerIn: parent
+            text: parent.modelData.name
+            textFormat: Text.PlainText
+            color: parent.current ? Color.background : field.foreground
+            font.family: Style.font.menuFamily
+            font.pixelSize: Style.font.caption
+          }
+          MouseArea {
+            id: choiceArea
+            anchors.fill: parent
+            hoverEnabled: true
+            onClicked: field.edited(parent.modelData.id)
+          }
+        }
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------- color
+
+  Component {
+    id: colorC
+    Column {
+      spacing: Style.space(5)
+
+      Flow {
+        width: field.width
+        spacing: Style.space(5)
+        Repeater {
+          model: D.COLOR_ROLES
+          Rectangle {
+            required property var modelData
+            readonly property bool current: String(modelData.id) === String(field.value)
+            width: Style.space(22)
+            height: Style.space(22)
+            radius: 4
+            color: swatch.roleColor(modelData.id)
+            border.width: current ? 2 : 1
+            border.color: current ? field.accent : field.line
+            DesignerSwatch { id: swatch }
+            MouseArea {
+              anchors.fill: parent
+              hoverEnabled: true
+              onClicked: field.edited(parent.modelData.id)
+            }
+          }
+        }
+      }
+
+      Rectangle {
+        width: field.width
+        height: Style.space(24)
+        radius: 4
+        color: field.well
+        border.width: 1
+        border.color: hexEntry.activeFocus ? field.accent : field.line
+        TextInput {
+          id: hexEntry
+          anchors.fill: parent
+          anchors.leftMargin: Style.space(8)
+          anchors.rightMargin: Style.space(8)
+          verticalAlignment: TextInput.AlignVCenter
+          text: String(field.value || "").charAt(0) === "#" ? String(field.value) : ""
+          color: field.foreground
+          selectionColor: field.accent
+          selectByMouse: true
+          font.family: Style.font.menuFamily
+          font.pixelSize: Style.font.caption
+          onTextEdited: if (/^#[0-9A-Fa-f]{6}$/.test(text)) field.edited(text)
+          Text {
+            anchors.fill: parent
+            verticalAlignment: Text.AlignVCenter
+            visible: hexEntry.text.length === 0
+            text: "or #rrggbb"
+            color: field.muted
+            font: hexEntry.font
+          }
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------ bool
+
+  Component {
+    id: boolC
+    // The switch keeps its own size; the Item around it takes the width the
+    // Loader hands down.
+    Item {
+      implicitHeight: toggle.height
+
+      Rectangle {
+        id: toggle
+        width: Style.space(46)
+        height: Style.space(24)
+        radius: height / 2
+        color: field.value === true ? field.accent : field.well
+        border.width: 1
+        border.color: field.value === true ? field.accent : field.line
+        Behavior on color { ColorAnimation { duration: 100 } }
+
+        Rectangle {
+          x: field.value === true ? parent.width - width - Style.space(3) : Style.space(3)
+          anchors.verticalCenter: parent.verticalCenter
+          width: parent.height - Style.space(6)
+          height: width
+          radius: width / 2
+          color: field.value === true ? Color.background : field.foreground
+          Behavior on x { NumberAnimation { duration: 110; easing.type: Easing.OutCubic } }
+        }
+
+        MouseArea {
+          anchors.fill: parent
+          onClicked: field.edited(field.value !== true)
+        }
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------ file
+
+  Component {
+    id: fileC
+    Row {
+      spacing: Style.space(6)
+      Rectangle {
+        width: Style.space(70)
+        height: Style.space(26)
+        radius: 4
+        color: browseArea.containsMouse ? Qt.rgba(field.foreground.r, field.foreground.g, field.foreground.b, 0.16) : field.well
+        border.width: 1
+        border.color: field.line
+        Text {
+          anchors.centerIn: parent
+          text: "Choose…"
+          color: field.foreground
+          font.family: Style.font.menuFamily
+          font.pixelSize: Style.font.caption
+        }
+        MouseArea {
+          id: browseArea
+          anchors.fill: parent
+          hoverEnabled: true
+          onClicked: field.pickFileRequested()
+        }
+      }
+      Text {
+        anchors.verticalCenter: parent.verticalCenter
+        width: field.width - Style.space(82)
+        text: String(field.value || "").length > 0 ? String(field.value).split("/").pop() : "none"
+        textFormat: Text.PlainText
+        color: field.muted
+        font.family: Style.font.menuFamily
+        font.pixelSize: Style.font.caption
+        elide: Text.ElideMiddle
+      }
+    }
+  }
+
+  // ------------------------------------------------------------------ code
+
+  Component {
+    id: codeC
+    Rectangle {
+      implicitHeight: Style.space(190)
+      radius: 4
+      color: field.well
+      border.width: 1
+      border.color: codeEdit.activeFocus ? field.accent : field.line
+      clip: true
+
+      Flickable {
+        anchors.fill: parent
+        anchors.margins: Style.space(8)
+        contentWidth: Math.max(width, codeEdit.contentWidth)
+        contentHeight: Math.max(height, codeEdit.contentHeight)
+        clip: true
+        boundsBehavior: Flickable.StopAtBounds
+
+        TextEdit {
+          id: codeEdit
+          width: Math.max(parent.width, contentWidth)
+          text: String(field.value || "")
+          textFormat: TextEdit.PlainText
+          wrapMode: TextEdit.NoWrap
+          selectByMouse: true
+          color: field.foreground
+          selectionColor: field.accent
+          font.family: Style.font.family
+          font.pixelSize: Style.font.caption
+          tabStopDistance: font.pixelSize * 1.2
+          // Rebuilding the snippet on every keystroke would flood the canvas
+          // with half-typed QML; it goes in when the box is left, or on
+          // Ctrl+Enter.
+          onActiveFocusChanged: if (!activeFocus && text !== String(field.value || "")) field.edited(text)
+          Keys.onPressed: function(event) {
+            if ((event.modifiers & Qt.ControlModifier)
+                && (event.key === Qt.Key_Return || event.key === Qt.Key_Enter)) {
+              field.edited(codeEdit.text)
+              event.accepted = true
+            } else if (event.key === Qt.Key_Tab) {
+              codeEdit.insert(codeEdit.cursorPosition, "  ")
+              event.accepted = true
+            }
+          }
+        }
+      }
+
+      Text {
+        anchors.right: parent.right
+        anchors.bottom: parent.bottom
+        anchors.margins: Style.space(6)
+        text: "Ctrl+Enter applies"
+        color: field.muted
+        font.family: Style.font.menuFamily
+        font.pixelSize: Style.font.caption
+      }
+    }
+  }
+}

--- a/DesignerNode.qml
+++ b/DesignerNode.qml
@@ -1,0 +1,153 @@
+import QtQuick
+import qs.Commons
+import "designs"
+import "Designer.js" as D
+
+// One node on the designer's canvas: the real DesignerItem, plus the editing
+// chrome (outline, drag, resize handles) that never ships in a design file.
+//
+// Geometry comes from the layout's anchor rule measured against the item's
+// live size, so the canvas places things exactly where the generated anchors
+// will put them on the lock screen. `node` is a LayoutNode, so every binding
+// below repaints on its own when the piece is moved or restyled.
+Item {
+  id: nodeRoot
+
+  property var stage: null
+  property LayoutNode node: null
+
+  readonly property bool fill: node ? D.isFill(node) : false
+  readonly property bool selected: (stage && node) ? stage.selection.indexOf(node.nodeId) !== -1 : false
+  readonly property bool editing: stage ? stage.editing : false
+  // Canvas scale, so the chrome keeps a constant size on screen.
+  readonly property real vs: (stage && stage.viewScale > 0) ? stage.viewScale : 1
+  readonly property real hair: 1 / vs
+  readonly property real grip: 9 / vs
+
+  x: (fill || !node || !parent) ? 0 : D.xFor(node, width, parent.width)
+  y: (fill || !node || !parent) ? 0 : D.yFor(node, height, parent.height)
+  width: fill && parent ? parent.width : inner.width
+  height: fill && parent ? parent.height : inner.height
+
+  DesignerItem {
+    id: inner
+    lock: nodeRoot.stage
+    kind: nodeRoot.node ? nodeRoot.node.kind : "label"
+    fillParent: nodeRoot.fill
+    fixedWidth: nodeRoot.node ? nodeRoot.node.w : 0
+    fixedHeight: nodeRoot.node ? nodeRoot.node.h : 0
+    spec: nodeRoot.node ? nodeRoot.node.spec : ({})
+    customQml: (nodeRoot.node && nodeRoot.node.kind === "custom") ? String(nodeRoot.node.spec.qml || "") : ""
+  }
+
+  // An empty piece (a label with no text, a picture with no file) would be
+  // impossible to grab, so give it a footprint while editing.
+  Rectangle {
+    anchors.centerIn: parent
+    visible: nodeRoot.editing && !nodeRoot.fill && (nodeRoot.width < 8 || nodeRoot.height < 8)
+    width: 80
+    height: 30
+    color: Qt.rgba(1, 1, 1, 0.06)
+    border.width: nodeRoot.hair
+    border.color: Qt.rgba(1, 1, 1, 0.3)
+  }
+
+  Rectangle {
+    anchors.fill: parent
+    visible: nodeRoot.editing && (nodeRoot.selected || hoverArea.containsMouse)
+    color: "transparent"
+    border.width: nodeRoot.selected ? 2 * nodeRoot.hair : nodeRoot.hair
+    border.color: nodeRoot.selected ? Color.accent : Qt.rgba(1, 1, 1, 0.45)
+  }
+
+  MouseArea {
+    id: hoverArea
+    anchors.fill: parent
+    // The full-screen backgrounds stay out of the way: a click that lands on
+    // one is a click on empty canvas, and the layer list is how they are
+    // picked. Otherwise nothing else could ever be deselected.
+    enabled: nodeRoot.editing && !nodeRoot.fill
+    hoverEnabled: true
+    acceptedButtons: Qt.LeftButton
+
+    property real pressX: 0
+    property real pressY: 0
+    property real startX: 0
+    property real startY: 0
+    property bool moving: false
+
+    onPressed: function(mouse) {
+      if (!nodeRoot.node || !nodeRoot.stage) return
+      nodeRoot.stage.nodePressed(nodeRoot.node.nodeId, (mouse.modifiers & Qt.ControlModifier) !== 0)
+      var p = mapToItem(nodeRoot.parent, mouse.x, mouse.y)
+      pressX = p.x
+      pressY = p.y
+      startX = nodeRoot.x
+      startY = nodeRoot.y
+      moving = false
+    }
+    onPositionChanged: function(mouse) {
+      if (!pressed || !nodeRoot.node || !nodeRoot.stage) return
+      var p = mapToItem(nodeRoot.parent, mouse.x, mouse.y)
+      var ddx = p.x - pressX
+      var ddy = p.y - pressY
+      // A couple of pixels of slop, so a click does not nudge anything.
+      if (!moving && Math.abs(ddx) < 3 && Math.abs(ddy) < 3) return
+      moving = true
+      nodeRoot.stage.nodeDragged(nodeRoot.node.nodeId, startX + ddx, startY + ddy)
+    }
+    onReleased: {
+      if (nodeRoot.stage) nodeRoot.stage.nodeDragEnded()
+      moving = false
+    }
+  }
+
+  // Resize handles: the right edge, the bottom edge and the corner. The
+  // top-left stays put, whatever the anchor is.
+  Repeater {
+    model: (nodeRoot.editing && nodeRoot.selected && nodeRoot.node && D.isSized(nodeRoot.node))
+      ? ["right", "bottom", "corner"] : []
+
+    Rectangle {
+      id: handle
+      required property string modelData
+      readonly property bool horizontal: modelData !== "bottom"
+      readonly property bool vertical: modelData !== "right"
+      readonly property bool square: nodeRoot.node ? D.isSquare(nodeRoot.node) : false
+      visible: !(square && modelData !== "corner")
+      width: nodeRoot.grip
+      height: nodeRoot.grip
+      radius: nodeRoot.hair
+      color: Color.accent
+      border.width: nodeRoot.hair
+      border.color: Qt.rgba(0, 0, 0, 0.6)
+      x: horizontal ? nodeRoot.width - width / 2 : (nodeRoot.width - width) / 2
+      y: vertical ? nodeRoot.height - height / 2 : (nodeRoot.height - height) / 2
+
+      MouseArea {
+        anchors.fill: parent
+        anchors.margins: -nodeRoot.grip / 2
+        property real pressX: 0
+        property real pressY: 0
+        property real startW: 0
+        property real startH: 0
+        onPressed: function(mouse) {
+          var p = mapToItem(nodeRoot.parent, mouse.x, mouse.y)
+          pressX = p.x
+          pressY = p.y
+          startW = nodeRoot.width
+          startH = nodeRoot.height
+        }
+        onPositionChanged: function(mouse) {
+          if (!pressed || !nodeRoot.node || !nodeRoot.stage) return
+          var p = mapToItem(nodeRoot.parent, mouse.x, mouse.y)
+          var w = handle.horizontal ? startW + (p.x - pressX) : startW
+          var h = handle.vertical ? startH + (p.y - pressY) : startH
+          if (handle.square) { w = Math.max(w, h); h = w }
+          nodeRoot.stage.nodeResized(nodeRoot.node.nodeId, Math.max(4, Math.round(w)), Math.max(1, Math.round(h)))
+        }
+        onReleased: if (nodeRoot.stage) nodeRoot.stage.nodeDragEnded()
+      }
+    }
+  }
+}

--- a/DesignerStage.qml
+++ b/DesignerStage.qml
@@ -1,0 +1,46 @@
+import QtQuick
+import "designs"
+import "Designer.js" as D
+
+// The designer's canvas, and the preview behind every component thumbnail:
+// a real DesignBase with the layout's nodes inside it, at the screen's own
+// size. Everything it renders is what the lock screen renders.
+DesignBase {
+  id: board
+
+  // LayoutNode objects. Reassign the array when pieces are added, removed or
+  // restacked; editing a piece needs nothing here, the canvas binds to it.
+  property var nodes: []
+  property bool editing: false
+  property var selection: []
+  property real viewScale: 1
+
+  // Nothing here may take the keyboard: the designer owns it.
+  inputEnabled: false
+  flashOnFail: false
+
+  signal nodePressed(string id, bool additive)
+  signal nodeDragged(string id, real x, real y)
+  signal nodeResized(string id, real w, real h)
+  signal nodeDragEnded()
+
+  // Where a node ended up, which is what the designer needs to turn a drag
+  // into an offset and to work out what a component's pieces look like.
+  function rectOf(index) {
+    var it = repeater.itemAt(index)
+    if (!it) return { x: 0, y: 0, w: 0, h: 0 }
+    return { x: it.x, y: it.y, w: it.width, h: it.height }
+  }
+
+  Repeater {
+    id: repeater
+    model: board.nodes
+    delegate: DesignerNode {
+      required property var modelData
+      // `board`, not `stage`: a delegate property named the same as the id it
+      // is bound to would just bind to itself.
+      stage: board
+      node: modelData
+    }
+  }
+}

--- a/DesignerSwatch.qml
+++ b/DesignerSwatch.qml
@@ -1,0 +1,22 @@
+import QtQuick
+import qs.Commons
+
+// The theme color behind a role name, for the inspector's color swatches.
+// Same table as DesignerItem.roleColor, kept here so the panel can draw the
+// choices without instantiating a design piece.
+QtObject {
+  function roleColor(role) {
+    var r = String(role || "text")
+    if (r.charAt(0) === "#") return r
+    switch (r) {
+    case "accent": return Color.lock.borderActive
+    case "error": return Color.lock.textError
+    case "placeholder": return Color.lock.placeholder
+    case "surface": return Color.lock.background
+    case "background": return Color.background
+    case "black": return "#000000"
+    case "white": return "#ffffff"
+    }
+    return Color.lock.text
+  }
+}

--- a/DesignerThumb.qml
+++ b/DesignerThumb.qml
@@ -1,0 +1,37 @@
+import QtQuick
+import "designs"
+
+// A saved component drawn at its real size and scaled into the palette, so
+// the thing you drag looks like the thing you get. It borrows the canvas's
+// DesignBase as `lock`, which is why it costs nothing but the pieces.
+Item {
+  id: thumb
+
+  property var lock: null
+  property var comp: null
+  clip: true
+
+  Item {
+    width: Math.max(1, thumb.comp ? thumb.comp.w : 1)
+    height: Math.max(1, thumb.comp ? thumb.comp.h : 1)
+    scale: Math.min(thumb.width / width, thumb.height / height, 1)
+    transformOrigin: Item.TopLeft
+    x: (thumb.width - width * scale) / 2
+    y: (thumb.height - height * scale) / 2
+
+    Repeater {
+      model: thumb.comp ? thumb.comp.nodes : []
+      delegate: DesignerItem {
+        required property var modelData
+        lock: thumb.lock
+        kind: modelData.kind
+        spec: modelData.spec
+        fixedWidth: modelData.w
+        fixedHeight: modelData.h
+        customQml: modelData.kind === "custom" ? String(modelData.spec.qml || "") : ""
+        x: modelData.rx
+        y: modelData.ry
+      }
+    }
+  }
+}

--- a/Explorer.qml
+++ b/Explorer.qml
@@ -6,6 +6,7 @@ import qs.Commons
 import qs.Ui
 import "designs"
 import "Designs.js" as Designs
+import "Designer.js" as Layout
 
 Item {
   id: root
@@ -52,6 +53,12 @@ Item {
   property bool fullPreview: false
   property bool editing: false
   property var editingDesign: null
+  // The visual designer, which takes over the card the same way the code
+  // editor does. `designerPaused` holds the session open across the file
+  // dialog, which needs the explorer to step aside.
+  property bool designing: false
+  property var designingDesign: null
+  property bool designerPaused: false
   property string category: "all"
 
   readonly property var categories: Designs.categories()
@@ -101,6 +108,7 @@ Item {
 
   function handleEscape() {
     if (confirmingDelete.length > 0) { confirmingDelete = ""; return }
+    if (designing) { designerView.requestClose(); return }
     if (editing) { closeEditor(); return }
     if (bootEditing.length > 0) { closeBootEditor(); return }
     if (fullPreview) { fullPreview = false; return }
@@ -574,6 +582,14 @@ Item {
   function open(payloadJson) {
     root.opened = true
     root.fullPreview = false
+    // Back from the file dialog: drop straight into the design that was open.
+    if (root.designerPaused) {
+      root.designerPaused = false
+      root.requestedTab = ""
+      if (root.service && typeof root.service.rescanUserDesigns === "function") root.service.rescanUserDesigns()
+      Qt.callLater(function() { designerView.focusCanvas() })
+      return
+    }
     root.mainTab = root.requestedTab.length > 0 ? root.requestedTab : "styling"
     root.requestedTab = ""
     root.category = "all"
@@ -602,9 +618,15 @@ Item {
   function dismiss() {
     root.opened = false
     root.fullPreview = false
+    if (root.designerPaused) {
+      if (root.shell && typeof root.shell.hide === "function") root.shell.hide(root.pluginId)
+      return
+    }
     root.mainTab = "styling"
     root.editing = false
     root.editingDesign = null
+    root.designing = false
+    root.designingDesign = null
     if (root.shell && typeof root.shell.hide === "function") root.shell.hide(root.pluginId)
   }
 
@@ -743,12 +765,66 @@ Item {
 
   function customizeSelected() {
     if (!root.selectedDesign || !root.service) return
-    if (root.selectedDesign.path) { openEditor(root.selectedDesign); return }
+    if (root.selectedDesign.path) { editSelected(); return }
     root.service.customizeDesign(root.selectedDesign.id)
+  }
+
+  // A design of your own opens where it was made: the designer for a layout,
+  // the code editor for hand-written QML.
+  function editSelected() {
+    var d = root.selectedDesign
+    if (!d || !d.path) return
+    if (d.designer) root.openDesigner(d)
+    else root.openEditor(d)
   }
 
   function newDesign() {
     if (root.service) root.service.customizeDesign("new")
+  }
+
+  // A new visual design: the service writes the starter layout, and the
+  // designerDesignCreated signal below opens it.
+  function newDesignerDesign() {
+    if (!root.service) return
+    root.service.createDesignerDesign(Layout.generate(Layout.starterDoc("My Layout"), root.pluginId))
+  }
+
+  function openDesigner(design) {
+    if (!design || !design.path) return
+    root.designingDesign = design
+    root.designing = true
+    root.editing = false
+    root.fullPreview = false
+    // Re-read it: the same design may have been edited as code in between.
+    Qt.callLater(function() { designerView.load() })
+    // And hand it the keyboard once the card is really up. Asking on the same
+    // tick does not stick — the shortcuts then stay dead until the first click
+    // lands inside the designer.
+    designerFocusTimer.restart()
+  }
+
+  Timer {
+    id: designerFocusTimer
+    interval: 150
+    repeat: false
+    onTriggered: if (root.designing) designerView.focusCanvas()
+  }
+
+  function closeDesigner() {
+    root.designing = false
+    root.designingDesign = null
+    if (root.service && typeof root.service.rescanUserDesigns === "function") root.service.rescanUserDesigns()
+    Qt.callLater(function() { keyCatcher.forceActiveFocus() })
+  }
+
+  // The Image piece needs the file dialog, which needs the keyboard. Save
+  // first, step aside, and come back into the same design.
+  function pickDesignerImage() {
+    if (!root.service) return
+    designerView.save()
+    root.designerPaused = true
+    root.dismiss()
+    root.service.pickImage(true)
   }
 
   function openEditor(design) {
@@ -786,6 +862,17 @@ Item {
         var d = Designs.byId(id)
         if (d) root.openEditor(d)
       })
+    }
+    function onDesignerDesignCreated(id, path) {
+      if (!root.opened) return
+      Qt.callLater(function() {
+        root.selectById(id)
+        var d = Designs.byId(id)
+        if (d) root.openDesigner(d)
+      })
+    }
+    function onImagePicked(path) {
+      designerView.fileFieldPicked(path)
     }
     function onClipDesignAdded(id) {
       root.mainTab = "animation"
@@ -859,11 +946,13 @@ Item {
       // Embedded lock previews can pull keyboard focus; reclaim it whenever
       // it drifts, except while a real editor field wants it.
       onActiveFocusChanged: {
-        if (!activeFocus && root.opened && root.bootEditing.length === 0 && !root.editing && !root.customDelayEditing)
+        if (!activeFocus && root.opened && root.bootEditing.length === 0 && !root.editing
+            && !root.designing && !root.customDelayEditing)
           Qt.callLater(function() { keyCatcher.forceActiveFocus() })
       }
       Keys.onPressed: function(event) {
         if (event.key === Qt.Key_Escape) { root.handleEscape(); event.accepted = true; return }
+        if (root.designing) return
         if (root.editing) return
         if (root.bootEditing.length > 0) return
         if (root.customDelayEditing) return
@@ -879,8 +968,12 @@ Item {
         } else if (event.key === Qt.Key_C) {
           root.customizeSelected(); event.accepted = true
         } else if (event.key === Qt.Key_E) {
-          if (root.selectedDesign && root.selectedDesign.path) root.openEditor(root.selectedDesign)
+          if (root.selectedDesign && root.selectedDesign.path) root.editSelected()
           else root.customizeSelected()
+          event.accepted = true
+        } else if (event.key === Qt.Key_D) {
+          if (root.selectedDesign && root.selectedDesign.designer) root.openDesigner(root.selectedDesign)
+          else root.newDesignerDesign()
           event.accepted = true
         } else if (event.key === Qt.Key_N) {
           root.newDesign(); event.accepted = true
@@ -2486,6 +2579,38 @@ Item {
         }
       }
 
+      // "+ New design" at the top of the three: the visual designer, where a
+      // lock screen is put together by dragging pieces onto the screen.
+      Rectangle {
+        id: newDesignBtn
+        anchors.left: parent.left
+        anchors.leftMargin: card.contentLeftInset
+        anchors.bottom: newClipBtn.top
+        anchors.bottomMargin: Style.space(8)
+        width: root.sidebarW
+        height: Style.space(34)
+        color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, newDesignArea.containsMouse ? 0.28 : 0.14)
+        border.width: 1
+        border.color: Qt.rgba(root.accent.r, root.accent.g, root.accent.b, 0.6)
+        Behavior on color { ColorAnimation { duration: 100 } }
+
+        Text {
+          anchors.centerIn: parent
+          text: "+ New design"
+          color: root.foreground
+          font.family: root.fontFamily
+          font.pixelSize: Style.font.bodySmall
+          font.weight: Font.DemiBold
+        }
+
+        MouseArea {
+          id: newDesignArea
+          anchors.fill: parent
+          hoverEnabled: true
+          onClicked: root.newDesignerDesign()
+        }
+      }
+
       // "+ New clip" above it: your own video as an unlock clip design.
       Rectangle {
         id: newClipBtn
@@ -2860,7 +2985,8 @@ Item {
                 Text {
                   id: custLabel
                   anchors.centerIn: parent
-                  text: cell.modelData.path ? "Edit  E" : "Customize  C"
+                  text: cell.modelData.designer ? "Design  E"
+                    : (cell.modelData.path ? "Edit  E" : "Customize  C")
                   color: "#ffffff"
                   font.family: root.fontFamily
                   font.pixelSize: Style.font.caption
@@ -2996,7 +3122,7 @@ Item {
             if (root.mainTab === "editor") return "Changes save automatically   ·   Esc: back"
             if (root.mainTab === "boot") return "Click a card to pick it   ·   Apply writes it to the boot image   ·   B / Esc: back"
             if (root.mainTab === "settings") return "U / Esc: back"
-            return "Arrows: browse   Tab: category   Space: preview   Enter: select   C: customize   E: edit   N: new   X: delete   A: avatar   V: video   S: unlock clip   U: unlock effect   B: boot screen   Esc: close"
+            return "Arrows: browse   Space: preview   Enter: select   D: designer   C: customize   E: edit   N: new   X: delete   A: avatar   V: video   S: unlock clip   U: unlock effect   B: boot screen   Esc: close"
           }
           color: root.muted
           font.family: root.fontFamily
@@ -3118,6 +3244,45 @@ Item {
           screenHeight: panel.height
           onCloseRequested: root.closeEditor()
           onOpenExternalRequested: function(path) { root.openExternal(path) }
+        }
+      }
+    }
+
+    BorderSurface {
+      id: designerCard
+      visible: root.designing
+      width: root.cardWidth
+      height: root.cardHeight
+      radius: root.cornerRadius
+      anchors.centerIn: parent
+      color: root.background
+      borderSpec: root.borderSpec
+
+      MouseArea { anchors.fill: parent; onClicked: {} }
+
+      Designer {
+        id: designerView
+        anchors.fill: parent
+        anchors.topMargin: designerCard.contentTopInset + root.contentMargin
+        anchors.bottomMargin: designerCard.contentBottomInset + root.contentMargin
+        anchors.leftMargin: designerCard.contentLeftInset + root.contentMargin
+        anchors.rightMargin: designerCard.contentRightInset + root.contentMargin
+        service: root.service
+        design: root.designing ? root.designingDesign : null
+        pluginId: root.pluginId
+        background: root.background
+        foreground: root.foreground
+        accent: root.accent
+        fontFamily: root.fontFamily
+        screenWidth: panel.width
+        screenHeight: panel.height
+        onCloseRequested: root.closeDesigner()
+        onUseRequested: if (root.service && root.designingDesign) root.service.setDesign(root.designingDesign.id)
+        onPickFileRequested: root.pickDesignerImage()
+        onOpenCodeRequested: function(path) {
+          // Straight from the canvas into the code, on the same file.
+          root.designing = false
+          root.openEditor(root.designingDesign)
         }
       }
     }

--- a/LayoutNode.qml
+++ b/LayoutNode.qml
@@ -1,0 +1,28 @@
+import QtQuick
+
+// One piece of a design, as a real QML object rather than a plain JS record.
+//
+// That is the whole point of it: the canvas binds straight to these
+// properties, so moving, resizing or restyling a piece repaints it without
+// anything having to be told to look again. Designer.js turns them into plain
+// objects for the file and back.
+QtObject {
+  // Not `id`, which QML keeps for itself. It only has to be unique inside one
+  // design; it becomes the object's id in the generated QML.
+  property string nodeId: ""
+  property string kind: "label"
+
+  // Which corner, edge or centre of the screen it holds on to, and how far it
+  // sits from there (positive is right and down).
+  property string anchor: "center"
+  property int dx: 0
+  property int dy: 0
+
+  // 0 means "size yourself from your content".
+  property int w: 0
+  property int h: 0
+
+  // The kind's own settings. Always assign a fresh object; the pieces watch
+  // this property, not the keys inside it.
+  property var spec: ({})
+}

--- a/README.md
+++ b/README.md
@@ -39,8 +39,11 @@ dialog is up and comes back when you are done), `Shift+A` clears it again. The d
 the user — Greeting Card, Split, Dock, Poster, Sheet, Island and Profile — use it, and fall back
 to your initial when there is none.
 
-`C` on any design copies it to `~/.config/omarchy/lock-designs/` (it shows up under Custom) and opens it in the
-built-in editor. `E` edits a custom design, `N` starts a new one from the template. `X` (or the
+`D` opens the visual designer — a new design, or the selected one if it was made there (see
+[The designer](#the-designer)). `C` on any design copies it to `~/.config/omarchy/lock-designs/`
+(it shows up under Custom) and opens it in the built-in code editor. `E` edits a design of your
+own, in the designer or the code editor depending on where it came from. `N` starts a new one
+from the template. `X` (or the
 Delete button on the card) removes a design of your own — press it twice, the first press just
 arms the button. Deleting a clip design also removes its video from `~/.config/omarchy/lock-videos/`
 unless something else still uses it (another design, the boot screen, the Motion video or the
@@ -153,6 +156,56 @@ extras/boot-vm-test.sh "$(plymouth/apply.sh terminal --stage-only)"
 
 boots your real kernel and initramfs in QEMU against a throwaway encrypted disk (passphrase:
 `omarchy`). Needs `qemu-system-x86`, `edk2-ovmf` and `qemu-ui-gtk`.
+
+## The designer
+
+"+ New design" in the explorer sidebar (or `D`) opens the visual designer: pieces on the left,
+your lock screen at its real size in the middle, the settings for whatever is selected on the
+right. Drag a piece onto the screen — or click it to drop one in the middle — move it around,
+and press Ctrl+S. There is no separate preview: the canvas renders through the same components
+the lock screen does, so what you arrange is what you get.
+
+What you can drag in: **Wallpaper**, **Video** and **Solid color** for the background; **Clock**,
+**Date**, **Greeting**, **Text**, **User name**, **Host name** and a **Status line** that turns
+into the failure message when a password is wrong; a **Password box** or bare **Dots** to type
+into; **Avatar** and **Image**; **Panel** and **Divider** to build a card out of; and **Custom
+QML** for anything else — that one is a box you write QML into, with `lock.now`, `lock.userName`,
+`lock.greeting()` and the rest in scope, exactly as in a hand-written design.
+
+Nothing is parked at fixed pixel coordinates. Every piece holds on to a corner, an edge or the
+middle of the screen ("Sticks to" in the inspector, picked from where you drop it) and keeps its
+distance from there, so a design made on one screen still looks right on another. Dragging snaps
+to the screen's centre lines and to the other pieces' edges, and arrow keys nudge by a pixel
+(Shift for ten).
+
+```
+drag / click a piece   add it            Ctrl+click       add to the selection
+arrows                 nudge (Shift 10)  Ctrl+D           duplicate
+Del                    remove            [ and ]          send back / bring forward
+Ctrl+Z / Ctrl+Shift+Z  undo / redo       Ctrl+S           save
+```
+
+### Your own components
+
+Select a piece — or several with Ctrl — press **Save as component** and give it a name. It goes
+into `~/.config/omarchy/lock-components/` as one small JSON file and shows up at the top of the
+palette, previewed live, ready to drag into any design from then on. A component keeps the
+relative positions of everything in it, so a card built out of a panel, an avatar and a greeting
+comes back as that card. Backgrounds are not saved into components — they cover the whole screen,
+so there is nothing to place. The `✕` on a component removes it.
+
+Because a component is just a piece of a layout, a Custom QML piece can be saved as one too:
+write the QML once, name it, and it becomes a block you drag in like any other.
+
+### What it writes
+
+The designer saves an ordinary design into `~/.config/omarchy/lock-designs/`, so it appears under
+Custom next to everything else and can be applied, previewed and deleted the same way. The file is
+a `DesignBase` with one `DesignerItem` per piece, and the layout itself sits on a single comment
+line at the top — that line is what the designer reads when you open the design again. **Edit the
+code by hand and the next save from the designer overwrites it**, so pick one: "Edit code" in the
+designer toolbar moves a design over to the code editor for good, and `E` on a design opens it
+wherever it was made.
 
 ## Your own designs
 

--- a/Service.qml
+++ b/Service.qml
@@ -420,6 +420,159 @@ echo "$target"
     }
   }
 
+  // ---------------------------------------------------------------- designer
+  //
+  // The visual designer writes ordinary designs into the same folder; a
+  // layout comment at the top is what tells it apart, and is what lets the
+  // designer open one again. Explorer.qml owns the editing, the service owns
+  // the files.
+
+  signal designerDesignCreated(string id, string path)
+
+  // Makes the file and hands its path back, so the explorer can drop straight
+  // into the designer on it.
+  function createDesignerDesign(content) {
+    if (designerCreateProc.running) return false
+    designerCreateProc.command = ["bash", "-c", designerCreateScript, "newdesign", userDesignsDir, String(content)]
+    designerCreateProc.running = true
+    return true
+  }
+
+  readonly property string designerCreateScript: '
+set -e
+dir="$1"; content="$2"
+mkdir -p "$dir"
+target="$dir/MyLayout.qml"; n=2
+while [[ -e $target ]]; do target="$dir/MyLayout$n.qml"; n=$((n+1)); done
+printf %s "$content" > "$target"
+echo "$target"
+'
+
+  Process {
+    id: designerCreateProc
+    stdout: StdioCollector {
+      id: designerCreateOut
+      waitForEnd: true
+      onStreamFinished: {
+        var target = String(designerCreateOut.text || "").trim()
+        if (target.length === 0) return
+        var d = Designs.fromUserFile(target)
+        d.designer = true
+        Designs.setUser(Designs.USER.concat([d]))
+        root.designsRevision += 1
+        root.designerDesignCreated(d.id, target)
+        root.rescanUserDesigns()
+        root.logEvent("designer-design=" + d.id)
+      }
+    }
+  }
+
+  // -------------------------------------------------------------- components
+  //
+  // Pieces saved out of the designer, so they can be dropped into any design
+  // later. One JSON file each in ~/.config/omarchy/lock-components, written
+  // on a single line; the scan below reads them all in one go.
+
+  readonly property string componentsDir: home + "/.config/omarchy/lock-components"
+  property var components: []
+
+  function rescanComponents() {
+    if (!componentsProc.running) componentsProc.running = true
+  }
+
+  function saveComponent(slug, json) {
+    var safe = String(slug || "").toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "")
+    if (safe.length === 0 || String(json || "").length === 0) return false
+    if (componentSaveProc.running) return false
+    componentSaveProc.command = ["bash", "-c",
+      'mkdir -p "$1" && printf %s "$3" > "$1/$2.json"', "savecomponent", componentsDir, safe, String(json)]
+    componentSaveProc.running = true
+    logEvent("component-saved=" + safe)
+    return true
+  }
+
+  function deleteComponent(slug) {
+    var safe = String(slug || "").toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-+|-+$/g, "")
+    if (safe.length === 0) return false
+    if (componentDeleteProc.running) return false
+    componentDeleteProc.command = ["bash", "-c",
+      'rm -f -- "$1/$2.json"', "delcomponent", componentsDir, safe]
+    componentDeleteProc.running = true
+    logEvent("component-deleted=" + safe)
+    return true
+  }
+
+  Process {
+    id: componentsProc
+    running: true
+    // slug<TAB>json, one component per line. The files the designer writes
+    // have no newlines in them; tr keeps a hand-edited one from splitting the
+    // listing across lines.
+    command: ["bash", "-c",
+      'dir="$1"; mkdir -p "$dir"; for f in "$dir"/*.json; do [ -e "$f" ] || continue; printf "%s\\t" "$(basename "$f" .json)"; tr -d "\\n" < "$f"; printf "\\n"; done',
+      "components", root.componentsDir]
+    stdout: StdioCollector {
+      id: componentsOut
+      waitForEnd: true
+      onStreamFinished: {
+        var lines = String(componentsOut.text || "").split("\n")
+        var list = []
+        for (var i = 0; i < lines.length; i++) {
+          var tab = lines[i].indexOf("\t")
+          if (tab === -1) continue
+          var slug = lines[i].substring(0, tab).trim()
+          try {
+            var comp = JSON.parse(lines[i].substring(tab + 1))
+            if (comp && comp.nodes instanceof Array) list.push({ slug: slug, comp: comp })
+          } catch (e) {
+            console.warn("lock-explorer: cannot read component", slug, e)
+          }
+        }
+        list.sort(function(a, b) { return String(a.comp.name).localeCompare(String(b.comp.name)) })
+        if (JSON.stringify(list) === JSON.stringify(root.components)) return
+        root.components = list
+      }
+    }
+  }
+
+  Process {
+    id: componentSaveProc
+    onExited: root.rescanComponents()
+  }
+
+  Process {
+    id: componentDeleteProc
+    onExited: root.rescanComponents()
+  }
+
+  // The file dialog again, for the designer's Image piece. Same dance as the
+  // avatar: the explorer steps aside while it is up.
+  signal imagePicked(string path)
+  property bool imagePickReopens: false
+
+  function pickImage(reopenExplorer) {
+    if (imagePickProc.running) return false
+    imagePickReopens = reopenExplorer === true
+    imagePickProc.running = true
+    return true
+  }
+
+  Process {
+    id: imagePickProc
+    command: ["omarchy-file-select", "--title", "Pick an image for the design", "--extensions", "png jpg jpeg webp svg"]
+    stdout: StdioCollector {
+      id: imagePickOut
+      waitForEnd: true
+      onStreamFinished: {
+        var picked = String(imagePickOut.text || "").trim().split("\n")[0] || ""
+        if (picked.length > 0) root.imagePicked(picked)
+        if (root.imagePickReopens && root.shell && typeof root.shell.summon === "function")
+          root.shell.summon(root.pluginId, "{}")
+        root.imagePickReopens = false
+      }
+    }
+  }
+
   // ------------------------------------------------------------------ avatar
 
   function setAvatar(path) {
@@ -1874,7 +2027,7 @@ echo "$out"
     // Files built on ClipDesign are tagged (with their clip file when it is
     // named inline) so they keep their animation flag and their video across
     // rescans.
-    command: ["bash", "-c", "for f in \"$0\"/*.qml; do [ -e \"$f\" ] || continue; c=$(grep -o 'clipName: \"[^\"]*\"' \"$f\" 2>/dev/null | head -1 | cut -d'\"' -f2); if [ -n \"$c\" ]; then printf '%s\\tclip\\t%s\\n' \"$f\" \"$c\"; elif grep -q ClipDesign \"$f\" 2>/dev/null; then printf '%s\\tclip\\n' \"$f\"; else printf '%s\\n' \"$f\"; fi; done", root.userDesignsDir]
+    command: ["bash", "-c", "for f in \"$0\"/*.qml; do [ -e \"$f\" ] || continue; c=$(grep -o 'clipName: \"[^\"]*\"' \"$f\" 2>/dev/null | head -1 | cut -d'\"' -f2); if [ -n \"$c\" ]; then printf '%s\\tclip\\t%s\\n' \"$f\" \"$c\"; elif grep -q ClipDesign \"$f\" 2>/dev/null; then printf '%s\\tclip\\n' \"$f\"; elif grep -q '// designer:1:' \"$f\" 2>/dev/null; then printf '%s\\tdesigner\\n' \"$f\"; else printf '%s\\n' \"$f\"; fi; done", root.userDesignsDir]
     stdout: StdioCollector {
       waitForEnd: true
       onStreamFinished: {
@@ -1883,6 +2036,11 @@ echo "$out"
           var parts = l.split("\t")
           var d = Designs.fromUserFile(parts[0].trim())
           if (parts.length > 1 && parts[1].trim() === "clip") { d.anim = true; d.clip = true }
+          // Made in the designer: E opens it there instead of in the code editor.
+          if (parts.length > 1 && parts[1].trim() === "designer") {
+            d.designer = true
+            d.description = "Made in the designer"
+          }
           if (parts.length > 2 && parts[2].trim().length > 0) d.clipFile = parts[2].trim()
           return d
         })
@@ -2274,6 +2432,17 @@ echo "$out"
     function rescanDesigns(): string {
       root.rescanUserDesigns()
       return "ok"
+    }
+
+    function rescanComponents(): string {
+      root.rescanComponents()
+      return "ok"
+    }
+
+    function components(): string {
+      var names = []
+      for (var i = 0; i < root.components.length; i++) names.push(root.components[i].comp.name)
+      return names.length > 0 ? names.join("\n") : "none"
     }
 
     function avatar(): string {

--- a/designs/Aurora.qml
+++ b/designs/Aurora.qml
@@ -82,6 +82,7 @@ DesignBase {
     Column {
       anchors.horizontalCenter: parent.horizontalCenter
       spacing: 4
+      opacity: lock.snapshotMode ? 0 : 1
       Text {
         anchors.horizontalCenter: parent.horizontalCenter
         text: Qt.formatTime(lock.now, "HH:mm")

--- a/designs/Cinema.qml
+++ b/designs/Cinema.qml
@@ -28,6 +28,7 @@ DesignBase {
       anchors.left: parent.left
       anchors.leftMargin: lock.pad
       anchors.verticalCenter: parent.verticalCenter
+      opacity: lock.snapshotMode ? 0 : 1
       text: Qt.formatTime(lock.now, "HH:mm")
       color: "#f2f2f2"
       font.family: Style.font.family
@@ -38,6 +39,7 @@ DesignBase {
       anchors.right: parent.right
       anchors.rightMargin: lock.pad
       anchors.verticalCenter: parent.verticalCenter
+      opacity: lock.snapshotMode ? 0 : 1
       text: Qt.formatDate(lock.now, "dddd d MMMM yyyy").toUpperCase()
       color: "#bdbdbd"
       font.family: Style.font.family

--- a/designs/DesignerItem.qml
+++ b/designs/DesignerItem.qml
@@ -1,0 +1,382 @@
+import QtQuick
+import QtQuick.Effects
+import qs.Commons
+
+// One piece of a design made in the visual designer. The designer's canvas and
+// the generated design file both render through this, so what you arrange is
+// exactly what the lock screen draws.
+//
+// `spec` carries the settings for the kind (see Designer.js for the list). It
+// is read through p(), which keeps every binding depending on `spec` as a
+// whole — the designer hands over a fresh object on each edit and the piece
+// repaints.
+Item {
+  id: piece
+
+  property var lock: null
+  property string kind: "label"
+  property var spec: ({})
+
+  function p(key, fallback) {
+    if (spec && spec[key] !== undefined && spec[key] !== null) return spec[key]
+    return fallback
+  }
+
+  // Only the designer's canvas sets this: it holds the "Custom QML" snippet
+  // as text and builds it here. A generated design file carries the same
+  // snippet inline as a child instead, where `lock` resolves to the design —
+  // exactly what it resolves to in here.
+  property string customQml: ""
+  property string customError: ""
+  property Item customItem: null
+
+  onCustomQmlChanged: rebuildCustom()
+  Component.onCompleted: if (customQml.length > 0) rebuildCustom()
+
+  function rebuildCustom() {
+    if (customItem) { customItem.destroy(); customItem = null }
+    customError = ""
+    if (kind !== "custom" || customQml.length === 0) return
+    var src = 'import QtQuick\n'
+      + 'import QtQuick.Effects\n'
+      + 'import QtMultimedia\n'
+      + 'import qs.Commons\n'
+      + 'import "' + Qt.resolvedUrl(".") + '"\n'
+      + 'Item {\n  anchors.fill: parent\n' + customQml + '\n}'
+    try {
+      customItem = Qt.createQmlObject(src, piece)
+    } catch (e) {
+      var msg = String(e)
+      if (e.qmlErrors && e.qmlErrors.length)
+        msg = e.qmlErrors.map(function(err) { return "line " + (err.lineNumber - 6) + ": " + err.message }).join("\n")
+      customError = msg
+    }
+  }
+
+  Text {
+    anchors.centerIn: parent
+    width: parent.width
+    visible: piece.customError.length > 0
+    text: piece.customError
+    textFormat: Text.PlainText
+    color: Color.lock.textError
+    font.family: Style.font.family
+    font.pixelSize: 13
+    wrapMode: Text.Wrap
+    maximumLineCount: 4
+    elide: Text.ElideRight
+    horizontalAlignment: Text.AlignHCenter
+  }
+
+  // Set from the layout: 0 means "size yourself from your content", which is
+  // what the text pieces do. `fillParent` is for the full-screen backgrounds.
+  property int fixedWidth: 0
+  property int fixedHeight: 0
+  property bool fillParent: false
+
+  // Where the password goes, for `inputItem` on the design. Null for
+  // everything that is not an input.
+  readonly property Item inputItem: (loader.item && loader.item.field !== undefined) ? loader.item.field : null
+
+  readonly property bool isText: kind === "clock" || kind === "date" || kind === "greeting"
+    || kind === "label" || kind === "username" || kind === "hostname" || kind === "status"
+
+  implicitWidth: loader.item ? loader.item.implicitWidth : 0
+  implicitHeight: loader.item ? loader.item.implicitHeight : 0
+  width: (fillParent && parent) ? parent.width : (fixedWidth > 0 ? fixedWidth : implicitWidth)
+  height: (fillParent && parent) ? parent.height
+    : (kind === "avatar" ? width : (fixedHeight > 0 ? fixedHeight : implicitHeight))
+
+  function roleColor(role) {
+    var r = String(role || "text")
+    if (r.charAt(0) === "#") return r
+    switch (r) {
+    case "accent": return Color.lock.borderActive
+    case "error": return Color.lock.textError
+    case "placeholder": return Color.lock.placeholder
+    case "surface": return Color.lock.background
+    case "background": return Color.background
+    case "black": return "#000000"
+    case "white": return "#ffffff"
+    }
+    return Color.lock.text
+  }
+
+  function tint(role, alpha) {
+    var c = roleColor(role)
+    return Qt.rgba(c.r, c.g, c.b, Math.max(0, Math.min(1, alpha === undefined ? 1 : alpha)))
+  }
+
+  // The words each text kind shows. Reads lock.now, so it ticks.
+  function displayText() {
+    if (!lock) return ""
+    switch (kind) {
+    case "clock": return Qt.formatTime(lock.now, String(p("format", "HH:mm")))
+    case "date": return Qt.formatDate(lock.now, String(p("format", "dddd, d MMMM")))
+    case "greeting": return lock.greeting() + (p("withName", true) ? ", " + lock.userName : "")
+    case "username": return lock.userName
+    case "hostname": return lock.hostName
+    case "status":
+      if (lock.failureMessage.length > 0) return lock.failureMessage
+      if (p("attempts", true) && lock.failedAttempts > 0)
+        return lock.failedAttempts + (lock.failedAttempts === 1 ? " failed attempt" : " failed attempts")
+      if (lock.authenticatingPassword) return "Checking…"
+      return String(p("text", ""))
+    }
+    return String(p("text", ""))
+  }
+
+  readonly property color textColor: (kind === "status" && lock && lock.failureMessage.length > 0)
+    ? Color.lock.textError
+    : tint(p("color", "text"), p("alpha", 1))
+
+  Loader {
+    id: loader
+    anchors.fill: parent
+    sourceComponent: {
+      switch (piece.kind) {
+      case "wallpaper": return wallpaperC
+      case "video": return videoC
+      case "color": return colorC
+      case "password": return passwordC
+      case "dots": return dotsC
+      case "avatar": return avatarC
+      case "image": return imageC
+      case "panel": return panelC
+      case "line": return lineC
+      case "custom": return null
+      }
+      return piece.isText ? textC : null
+    }
+  }
+
+  // ------------------------------------------------------------ backgrounds
+
+  Component {
+    id: wallpaperC
+    Wallpaper {
+      lock: piece.lock
+      blur: piece.p("blur", 0.85)
+      dim: piece.p("dim", 0.08)
+      vignette: piece.p("vignette", true)
+    }
+  }
+
+  Component {
+    id: videoC
+    VideoWallpaper {
+      lock: piece.lock
+      dim: piece.p("dim", 0.25)
+      vignette: piece.p("vignette", true)
+      playing: piece.lock ? piece.lock.videoPlaying : true
+    }
+  }
+
+  Component {
+    id: colorC
+    Rectangle { color: piece.tint(piece.p("color", "background"), piece.p("alpha", 1)) }
+  }
+
+  // ------------------------------------------------------------------ text
+
+  Component {
+    id: textC
+    Text {
+      readonly property string body: piece.displayText()
+      text: piece.p("caps", false) ? body.toUpperCase() : body
+      textFormat: Text.PlainText
+      color: piece.textColor
+      font.family: Style.font.family
+      font.pixelSize: Math.max(1, Math.round(piece.p("size", 22)))
+      font.weight: Math.round(piece.p("weight", 400))
+      font.letterSpacing: piece.p("spacing", 0)
+      horizontalAlignment: piece.p("align", "center") === "left" ? Text.AlignLeft
+        : (piece.p("align", "center") === "right" ? Text.AlignRight : Text.AlignHCenter)
+      verticalAlignment: Text.AlignVCenter
+      // A width set in the designer turns the label into a wrapping block;
+      // left on its own it hugs its text (and never feeds its own width back
+      // into the size it asks for).
+      wrapMode: piece.fixedWidth > 0 ? Text.Wrap : Text.NoWrap
+      elide: piece.fixedWidth > 0 ? Text.ElideRight : Text.ElideNone
+      layer.enabled: piece.p("shadow", false)
+      layer.effect: MultiEffect {
+        shadowEnabled: true
+        shadowColor: Qt.rgba(0, 0, 0, 0.55)
+        shadowBlur: 0.8
+        shadowVerticalOffset: 2
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------- input
+
+  Component {
+    id: passwordC
+    PasswordField {
+      id: passwordBox
+      property Item field: passwordBox.input
+      lock: piece.lock
+      placeholder: String(piece.p("placeholder", "Enter password"))
+      showLockGlyph: piece.p("glyph", true)
+      fontScale: piece.p("fontScale", 1)
+      textAlignment: piece.p("align", "center") === "left" ? TextInput.AlignLeft
+        : (piece.p("align", "center") === "right" ? TextInput.AlignRight : TextInput.AlignHCenter)
+      implicitWidth: 400
+      implicitHeight: 60
+    }
+  }
+
+  // No box: a dot per character, and a hidden LockInput taking the keys.
+  Component {
+    id: dotsC
+    Item {
+      id: dotsRoot
+      property alias field: hidden
+      implicitWidth: 320
+      implicitHeight: Math.max(24, Math.round(piece.p("size", 14) * 2))
+
+      readonly property int count: piece.lock ? piece.lock.passwordText.length : 0
+      readonly property int shown: Math.min(count, Math.max(1, Math.round(piece.p("max", 24))))
+      readonly property color dotColor: piece.lock && piece.lock.errorState
+        ? Color.lock.textError : piece.tint(piece.p("color", "text"), piece.p("alpha", 0.9))
+
+      LockInput {
+        id: hidden
+        lock: piece.lock
+        anchors.centerIn: parent
+        width: 1
+        height: 1
+        opacity: 0
+      }
+
+      Text {
+        anchors.centerIn: parent
+        visible: piece.lock ? (piece.lock.passwordVisible && dotsRoot.count > 0) : false
+        text: piece.lock ? piece.lock.passwordText : ""
+        textFormat: Text.PlainText
+        color: dotsRoot.dotColor
+        font.family: Style.font.family
+        font.pixelSize: Math.round(piece.p("size", 14) * 1.8)
+        font.letterSpacing: 2
+      }
+
+      Row {
+        anchors.centerIn: parent
+        visible: piece.lock ? !piece.lock.passwordVisible : true
+        spacing: Math.max(1, Math.round(piece.p("gap", 14)))
+        Repeater {
+          model: dotsRoot.shown
+          Rectangle {
+            width: Math.max(2, Math.round(piece.p("size", 14)))
+            height: width
+            radius: width / 2
+            color: dotsRoot.dotColor
+            antialiasing: true
+            opacity: 0
+            Component.onCompleted: opacity = 1
+            Behavior on opacity { NumberAnimation { duration: 140 } }
+          }
+        }
+      }
+    }
+  }
+
+  // ----------------------------------------------------------------- media
+
+  Component {
+    id: avatarC
+    Avatar {
+      lock: piece.lock
+      borderWidth: Math.round(piece.p("borderWidth", 0))
+      borderColor: piece.tint("text", piece.p("borderAlpha", 0.25))
+      shadow: piece.p("shadow", true)
+      implicitWidth: 120
+      implicitHeight: 120
+    }
+  }
+
+  Component {
+    id: imageC
+    Item {
+      implicitWidth: 240
+      implicitHeight: 160
+      Rectangle {
+        anchors.fill: parent
+        visible: picture.status !== Image.Ready
+        radius: piece.p("radius", 8)
+        color: piece.tint("text", 0.08)
+        border.width: 1
+        border.color: piece.tint("text", 0.2)
+        Text {
+          anchors.centerIn: parent
+          text: String(piece.p("path", "")).length > 0 ? "󰋫" : "󰋩"
+          color: piece.tint("text", 0.5)
+          font.family: Style.font.family
+          font.pixelSize: Math.min(48, Math.max(14, parent.height / 3))
+        }
+      }
+      Image {
+        id: picture
+        anchors.fill: parent
+        source: {
+          var path = String(piece.p("path", ""))
+          if (path.length === 0) return ""
+          if (path.indexOf("file://") === 0) return path
+          return "file://" + path.split("/").map(encodeURIComponent).join("/")
+        }
+        asynchronous: true
+        opacity: piece.p("alpha", 1)
+        fillMode: piece.p("mode", "crop") === "fit" ? Image.PreserveAspectFit
+          : (piece.p("mode", "crop") === "stretch" ? Image.Stretch : Image.PreserveAspectCrop)
+        sourceSize.width: Math.round(width)
+        sourceSize.height: Math.round(height)
+        layer.enabled: piece.p("radius", 8) > 0 && status === Image.Ready
+        layer.smooth: true
+        layer.effect: MultiEffect {
+          maskEnabled: true
+          maskSource: imageMask
+          maskThresholdMin: 0.5
+          maskSpreadAtMin: 0.05
+        }
+      }
+      Item {
+        id: imageMask
+        anchors.fill: parent
+        visible: false
+        layer.enabled: true
+        Rectangle { anchors.fill: parent; radius: piece.p("radius", 8); color: "white"; antialiasing: true }
+      }
+    }
+  }
+
+  // ---------------------------------------------------------------- shapes
+
+  Component {
+    id: panelC
+    Rectangle {
+      implicitWidth: 460
+      implicitHeight: 300
+      radius: Math.round(piece.p("radius", 20))
+      color: piece.tint(piece.p("color", "surface"), piece.p("alpha", 0.55))
+      border.width: piece.p("borderAlpha", 0.12) > 0 ? 1 : 0
+      border.color: piece.tint(piece.p("borderColor", "text"), piece.p("borderAlpha", 0.12))
+      antialiasing: true
+      layer.enabled: piece.p("shadow", true)
+      layer.effect: MultiEffect {
+        shadowEnabled: true
+        shadowColor: Qt.rgba(0, 0, 0, 0.5)
+        shadowBlur: 1.0
+        shadowVerticalOffset: 12
+      }
+    }
+  }
+
+  Component {
+    id: lineC
+    Rectangle {
+      implicitWidth: 320
+      implicitHeight: 1
+      color: piece.tint(piece.p("color", "text"), piece.p("alpha", 0.2))
+    }
+  }
+}

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.sirjul1337.lock-explorer",
   "name": "Lock Screen Explorer",
-  "version": "1.5.5",
+  "version": "1.6.0",
   "author": "SirJul1337",
   "license": "MIT",
   "description": "Lock screen designs for Omarchy with a picker to preview and switch between them",


### PR DESCRIPTION
Builds up to **v1.6.0**.

## What this adds

"+ New design" in the explorer sidebar (or `D`) opens a designer: palette on the left, the lock screen at its real size in the middle, settings for the selection on the right. Drag pieces in, move, resize and restyle them; arrows nudge, `[` / `]` restack, `Ctrl+Z` undoes, `Ctrl+S` saves.

The canvas is **not a preview**. It renders through the same `DesignerItem` the generated design file uses, so preview/output drift is structurally impossible.

Nothing sits at fixed pixel coordinates — each piece holds a corner, edge or the centre and keeps its distance from it, so designs survive a different screen. Dragging snaps to the screen's centre lines and to other pieces.

**Sixteen pieces**: wallpaper / video / solid colour backgrounds; clock, date, greeting, text, user name, host name, status line; password box and bare dots; avatar and image; panel and divider; and a Custom QML piece with `lock.now`, `lock.userName` etc. in scope.

**Reusable components.** Select one or more pieces → "Save as component" → they land in `~/.config/omarchy/lock-components/` as one JSON file and appear at the top of the palette with a live preview, draggable into any design, relative positions intact.

Designs stay ordinary files in `~/.config/omarchy/lock-designs/`. The layout rides on a single comment line at the top — that is what the designer reads when reopening, and what marks a design as designer-made so `E` routes to the designer rather than the code editor.

## Also here

A separate first commit hides the clock and date in boot snapshots for Aurora and Cinema — both drew their own time straight over the wallpaper, so a boot capture baked a frozen clock into the splash. The other designs already fade that chrome via `snapshotMode`.

## Verification

- 30 assertions driven against the real components under Quickshell: load, drop-and-centre, snap-to-guides, resize, property edits, re-anchor-without-moving, undo/redo, restack/duplicate/delete, component save → palette → drop with spacing intact, save → reload round trip. All pass.
- A generated design file was loaded as a real lock screen and renders correctly with `inputItem` wired.
- Driven by hand in the live shell as well, which caught two bugs unit-style checks missed: palette drag-and-drop was completely broken (`MouseArea.drag.target` mis-mapped the delta across coordinate systems, so the ghost flew off screen and dropped onto nothing), and the designer's keyboard shortcuts were dead until the first click landed inside it. Both fixed here.
- `omarchy plugin validate` and `qmllint -I $OMARCHY_PATH/shell` clean across all files.

## Known rough edge

The focus fix on opening the designer is not fully deterministic — one test run still needed a click inside the canvas before `Ctrl+A` took. Worth hardening before leaning on the shortcuts.
