### PR TITLE
Say the designer in the plugin description

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -5,7 +5,7 @@
   "version": "1.6.0",
   "author": "SirJul1337",
   "license": "MIT",
-  "description": "Lock screen designs for Omarchy with a picker to preview and switch between them",
+  "description": "Lock screen designs for Omarchy, a picker to preview and switch between them, and a designer for building your own",
   "kinds": [
     "service",
     "overlay"

--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
   "schemaVersion": 1,
   "id": "io.github.sirjul1337.lock-explorer",
   "name": "Lock Screen Explorer",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "author": "SirJul1337",
   "license": "MIT",
   "description": "Lock screen designs for Omarchy, a picker to preview and switch between them, and a designer for building your own",


### PR DESCRIPTION
The marketplace listing shows `manifest.json`'s `description`, and it still described the plugin as it was before 1.6.0 — designs and a picker, no mention of the designer that release is built around.

Two commits: the description, then the `v1.6.1` bump.

Cutting this as 1.6.1 rather than retagging 1.6.0, since that tag and release are already published.