### PR TITLE
fix: restore design selection and settings on Omarchy 4.0.3

### DIFF
--- a/Explorer.qml
+++ b/Explorer.qml
@@ -16,6 +16,9 @@ Item {
   property var manifest: null
   property var service: null
 
+  LocalSettings { id: localSettings; pluginId: root.pluginId }
+  property string selectionError: ""
+
   property bool opened: false
   // A resync that arrived while this window was never yet shown cannot grab a
   // frame (no scene graph); it parks here and runs on the next open.
@@ -68,7 +71,8 @@ Item {
     return Designs.stylings()
   }
   readonly property string pluginId: manifest && manifest.id ? String(manifest.id) : "io.github.sirjul1337.lock-explorer"
-  readonly property string activeDesignId: service ? service.designId : Designs.DEFAULT_ID
+  readonly property string activeDesignId: service ? service.designId
+    : String(localSettings.entry.design || Designs.DEFAULT_ID)
   readonly property var selectedDesign: designs.length > 0 ? designs[Math.max(0, Math.min(selectedIndex, designs.length - 1))] : null
   readonly property string avatarUrl: service ? service.avatarUrl : ""
 
@@ -896,10 +900,36 @@ Item {
     }
   }
 
+  function useDesign(id, dismissAfter) {
+    if (!Designs.byId(String(id)) || selectDesignProc.running) return
+    root.selectionError = ""
+    if (root.service && typeof root.service.setDesign === "function") {
+      if (root.service.setDesign(id)) {
+        if (dismissAfter) root.dismiss()
+      } else root.selectionError = "Could not select this lock design"
+      return
+    }
+    // The authentication service is intentionally private in Omarchy 4.0.3.
+    // Use its existing settings command, never expose the PAM service to UI.
+    selectDesignProc.dismissAfter = dismissAfter
+    selectDesignProc.command = ["omarchy-shell", "lock", "setDesign", String(id)]
+    selectDesignProc.running = true
+  }
+
+  Process {
+    id: selectDesignProc
+    property bool dismissAfter: false
+    stdout: StdioCollector { id: selectDesignOut; waitForEnd: true }
+    onExited: function(code) {
+      if (code === 0 && String(selectDesignOut.text || "").trim() === "ok") {
+        localSettings.reload()
+        if (dismissAfter) root.dismiss()
+      } else root.selectionError = "Could not select this lock design; please try again"
+    }
+  }
+
   function apply() {
-    if (!selectedDesign) return
-    if (root.service && typeof root.service.setDesign === "function") root.service.setDesign(selectedDesign.id)
-    root.dismiss()
+    if (selectedDesign) root.useDesign(selectedDesign.id, true)
   }
 
   PanelWindow {
@@ -1161,7 +1191,7 @@ Item {
             Text {
               id: activeLabel
               anchors.centerIn: parent
-              text: "Active: " + (Designs.byId(root.activeDesignId) ? Designs.byId(root.activeDesignId).name : root.activeDesignId)
+              text: root.selectionError || "Active: " + (Designs.byId(root.activeDesignId) ? Designs.byId(root.activeDesignId).name : root.activeDesignId)
               textFormat: Text.PlainText
               color: root.foreground
               font.family: root.fontFamily
@@ -3207,7 +3237,7 @@ Item {
               MouseArea {
                 anchors.fill: parent
                 onClicked: {
-                  if (root.service && root.editingDesign) root.service.setDesign(root.editingDesign.id)
+                  if (root.editingDesign) root.useDesign(root.editingDesign.id, false)
                 }
               }
             }
@@ -3277,7 +3307,7 @@ Item {
         screenWidth: panel.width
         screenHeight: panel.height
         onCloseRequested: root.closeDesigner()
-        onUseRequested: if (root.service && root.designingDesign) root.service.setDesign(root.designingDesign.id)
+        onUseRequested: if (root.designingDesign) root.useDesign(root.designingDesign.id, false)
         onPickFileRequested: root.pickDesignerImage()
         onOpenCodeRequested: function(path) {
           // Straight from the canvas into the code, on the same file.

--- a/LocalSettings.qml
+++ b/LocalSettings.qml
@@ -1,0 +1,40 @@
+import QtQuick
+import Quickshell
+import Quickshell.Io
+
+// Omarchy 4.0.3 no longer exposes shellConfig to third-party services.
+// Retain only this plugin's settings; writes still use the scoped shell API.
+Item {
+  id: root
+  property string pluginId: "io.github.sirjul1337.lock-explorer"
+  property string path: Quickshell.env("HOME") + "/.config/omarchy/shell.json"
+  property var entry: ({})
+  readonly property var config: ({ plugins: [entry] })
+
+  function reload() { settingsFile.reload() }
+
+  FileView {
+    id: settingsFile
+    path: root.path
+    watchChanges: true
+    printErrors: false
+    onFileChanged: reload()
+    onLoaded: {
+      try {
+        var parsed = JSON.parse(text())
+        var entries = Array.isArray(parsed.plugins) ? parsed.plugins : []
+        var selected = {}
+        for (var i = 0; i < entries.length; i++) {
+          if (entries[i] && entries[i].id === root.pluginId) {
+            selected = entries[i]
+            break
+          }
+        }
+        root.entry = selected
+      } catch (e) {
+        // A partial/invalid write must not reset the last known design.
+        console.warn("lock-explorer: cannot read saved plugin settings")
+      }
+    }
+  }
+}

--- a/Service.qml
+++ b/Service.qml
@@ -13,11 +13,15 @@ Item {
   property var manifest: null
   property string omarchyPath: ""
 
+  LocalSettings { id: localSettings; pluginId: root.pluginId }
+  readonly property var settingsConfig: shell && shell.shellConfig
+    ? shell.shellConfig : localSettings.config
+
   // selected design lives on this plugin's entry in shell.json
   readonly property string pluginId: manifest && manifest.id ? String(manifest.id) : "io.github.sirjul1337.lock-explorer"
   property string designOverride: ""
   readonly property string configuredDesignId: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -44,7 +48,7 @@ Item {
   // monitors get the companion screen.
   property string inputMonitorOverride: ""
   readonly property string configuredInputMonitor: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -62,7 +66,7 @@ Item {
   property string unlockOverride: ""
   property int unlockDurationOverride: -1
   readonly property string configuredUnlock: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -71,7 +75,7 @@ Item {
     return "none"
   }
   readonly property int configuredUnlockDuration: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -94,7 +98,7 @@ Item {
   readonly property int defaultBlankDelay: 5000
   property int blankDelayOverride: -1
   readonly property int configuredBlankDelay: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -111,7 +115,7 @@ Item {
   // in shell.json.
   property int keepDisplayOnOverride: -1
   readonly property bool configuredKeepDisplayOn: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -126,7 +130,7 @@ Item {
   // wants the initial back, an empty setting falls back to the usual dotfiles.
   property string avatarOverride: ""
   readonly property string configuredAvatar: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -151,7 +155,7 @@ Item {
   // it was cleared on purpose.
   property string videoOverride: ""
   readonly property string configuredVideo: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -164,7 +168,7 @@ Item {
 
   property string stingOverride: ""
   readonly property string configuredSting: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -182,7 +186,7 @@ Item {
 
   property int stingVolumeOverride: -1
   readonly property int configuredStingVolume: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -198,7 +202,7 @@ Item {
   // `clipSpeed` when it is not 1.
   property real clipSpeedOverride: -1
   readonly property real configuredClipSpeed: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -242,7 +246,7 @@ Item {
   }
 
   function pluginEntry() {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++)
       if (list[i] && String(list[i].id || "") === pluginId) return Util.cloneJson(list[i])
@@ -935,7 +939,7 @@ esac
   // entry as `clipWallpaper: true`, off by default.
   property int clipWallpaperOverride: -1
   readonly property bool configuredClipWallpaper: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -1007,7 +1011,7 @@ echo "$out"
   // through a single polkit prompt (see plymouth/apply.sh).
   property string bootOverride: ""
   readonly property string configuredBoot: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -1119,7 +1123,7 @@ echo "$out"
   property string bootCurrentTheme: ""
   property int bootResyncOverride: -1
   readonly property bool configuredBootResync: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -1253,7 +1257,7 @@ echo "$out"
   // on the plugin entry as bootClipSeconds.
   property int bootClipSecondsOverride: -1
   readonly property int configuredBootClipSeconds: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]
@@ -1363,7 +1367,7 @@ echo "$out"
   // prompt as the fallback. Saved on the plugin entry as bootRotation.
   property var bootRotationOverride: null
   readonly property var configuredBootRotation: {
-    var cfg = shell ? shell.shellConfig : null
+    var cfg = root.settingsConfig
     var list = cfg && Array.isArray(cfg.plugins) ? cfg.plugins : []
     for (var i = 0; i < list.length; i++) {
       var entry = list[i]


### PR DESCRIPTION
 ## Problem

  Omarchy 4.0.3 no longer exposes `shell.shellConfig` to third-party plugins and keeps authentication services private.

  Lock Screen Explorer consequently falls back to its default settings, and selecting a design does nothing when the picker’s `service` is null.

  ## Changes

  - Add a watched settings reader that retains only this plugin’s entry from `shell.json`.
  - Preserve existing settings when changing the selected design.
  - Use `omarchy-shell lock setDesign` when the authentication service is unavailable to the picker.
  - Route the picker, code editor, and visual designer’s “Use” actions through the same selection helper.
  - Display selection errors instead of silently dismissing the picker.
  - Retain the existing service-based path for older Omarchy versions.

  No changes to PAM, authentication, or the lock lifecycle.

  ## Validation

  Tested on Omarchy 4.0.3 with Quickshell 0.3.1:

  - Plugin validation and QML compilation passed.
  - Runtime selection through lock IPC passed with no authentication-service access.
  - Custom Weather design loaded without fallback and retained its password field.
  - Existing weather file and shell settings remained unchanged.
  - Security checker passed its available checks; ShellCheck was not installed.

  ## Scope

  This addresses saved settings and design selection. Other Explorer features that depend on direct service access may need follow-up compatibility work.

  Related to #15 and #16.